### PR TITLE
Add Disk I/O metrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Theo Gilbert"]
 edition = "2021"
 description = "Command line utility to supervize resource usage of processes"
-license = "Apache-2.0"
+license = "MIT"
 
 [features]
 netio = ["netinfo"]

--- a/src/core/metrics.rs
+++ b/src/core/metrics.rs
@@ -141,7 +141,7 @@ mod test_percent_metric {
     }
 }
 
-/// Metric representing input / output bitrates (e.g. network throughput)
+/// Metric representing input / output bitrates (e.g. network throughput) in bytes/sec
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub struct IOMetric {
     input: usize,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use simplelog::{ConfigBuilder, WriteLogger};
 use spv::core::collection::{MetricCollector, ProbeCollector};
 use spv::core::process::ProcessCollector;
 use spv::procfs::cpu_probe::CpuProbe;
+use spv::procfs::diskio_probe::DiskIOProbe;
 #[cfg(feature = "netio")]
 use spv::procfs::net_io_probe::NetIoProbe;
 use spv::procfs::process::ProcfsScanner;
@@ -67,6 +68,10 @@ fn build_collectors(resolution: Duration) -> Result<Vec<Box<dyn MetricCollector>
     let cpu_probe = CpuProbe::new().map_err(Error::CoreError)?;
     let cpu_collector = ProbeCollector::new(cpu_probe, resolution);
     collectors.push(Box::new(cpu_collector) as Box<dyn MetricCollector>);
+
+    let disk_io_probe = DiskIOProbe::default();
+    let disk_io_collector = ProbeCollector::new(disk_io_probe, resolution);
+    collectors.push(Box::new(disk_io_collector) as Box<dyn MetricCollector>);
 
     #[cfg(feature = "netio")]
     {

--- a/src/procfs/diskio_probe.rs
+++ b/src/procfs/diskio_probe.rs
@@ -1,0 +1,25 @@
+//! CPU Usage probing
+
+use crate::core::metrics::IOMetric;
+use crate::core::probe::Probe;
+use crate::core::process::Pid;
+use crate::core::Error;
+
+/// Probe implementation to measure the CPU usage (in percent) of processes
+pub struct DiskIOProbe {}
+
+impl DiskIOProbe {
+    pub fn default() -> Self {
+        DiskIOProbe {}
+    }
+}
+
+impl Probe<IOMetric> for DiskIOProbe {
+    fn name(&self) -> &'static str {
+        "Disk I/O"
+    }
+
+    fn probe(&mut self, pid: Pid) -> Result<IOMetric, Error> {
+        Ok(IOMetric::default())
+    }
+}

--- a/src/procfs/diskio_probe.rs
+++ b/src/procfs/diskio_probe.rs
@@ -1,4 +1,4 @@
-//! CPU Usage probing
+//! Disk usage probing
 
 use std::time::Duration;
 
@@ -11,7 +11,7 @@ use crate::procfs::rates::{ProcessesRates, PushMode};
 
 const IO_RATE_RETENTION: Duration = Duration::from_secs(1);
 
-/// Probe implementation to measure the CPU usage (in percent) of processes
+/// Probe implementation to measure and calculate the I/O usage of the disk
 pub struct DiskIOProbe {
     reader: Box<dyn ReadProcessData<PidIO>>,
     input_rate_calculator: ProcessesRates,

--- a/src/procfs/diskio_probe.rs
+++ b/src/procfs/diskio_probe.rs
@@ -1,16 +1,36 @@
 //! CPU Usage probing
 
+use std::time::Duration;
+
 use crate::core::metrics::IOMetric;
 use crate::core::probe::Probe;
 use crate::core::process::Pid;
 use crate::core::Error;
+use crate::procfs::parsers::{PidIO, ProcessDataReader, ReadProcessData};
+use crate::procfs::rates::{ProcessesRates, PushMode};
+
+const IO_RATE_RETENTION: Duration = Duration::from_secs(1);
 
 /// Probe implementation to measure the CPU usage (in percent) of processes
-pub struct DiskIOProbe {}
+pub struct DiskIOProbe {
+    reader: Box<dyn ReadProcessData<PidIO>>,
+    input_rate_calculator: ProcessesRates,
+    output_rate_calculator: ProcessesRates,
+}
+
+impl Default for DiskIOProbe {
+    fn default() -> Self {
+        Self::from_reader(Box::new(ProcessDataReader::new()))
+    }
+}
 
 impl DiskIOProbe {
-    pub fn default() -> Self {
-        DiskIOProbe {}
+    fn from_reader(reader: Box<dyn ReadProcessData<PidIO>>) -> Self {
+        DiskIOProbe {
+            reader,
+            input_rate_calculator: ProcessesRates::new(PushMode::Accumulative, IO_RATE_RETENTION),
+            output_rate_calculator: ProcessesRates::new(PushMode::Accumulative, IO_RATE_RETENTION),
+        }
     }
 }
 
@@ -20,6 +40,73 @@ impl Probe<IOMetric> for DiskIOProbe {
     }
 
     fn probe(&mut self, pid: Pid) -> Result<IOMetric, Error> {
-        Ok(IOMetric::default())
+        let pid_io = self
+            .reader
+            .read(pid)
+            .map_err(|e| Error::ProbingError(format!("Error probing disk IO stats for PID {}", pid), e.into()))?;
+
+        self.input_rate_calculator.push(pid, pid_io.read_bytes());
+        let input_rate = self
+            .input_rate_calculator
+            .rate(pid)
+            .map_err(|e| Error::ProbingError(format!("Error calculating input rate for PID {}", pid), e.into()))?;
+
+        self.output_rate_calculator.push(pid, pid_io.written_bytes());
+        let output_rate = self
+            .output_rate_calculator
+            .rate(pid)
+            .map_err(|e| Error::ProbingError(format!("Error calculating output rate for PID {}", pid), e.into()))?;
+
+        Ok(IOMetric::new(input_rate as usize, output_rate as usize))
+    }
+}
+
+#[cfg(test)]
+mod test_disk_io_probe {
+    use crate::core::metrics::IOMetric;
+    use crate::core::probe::Probe;
+    use crate::core::process::Pid;
+    use crate::procfs::diskio_probe::DiskIOProbe;
+    use crate::procfs::parsers::{PidIO, ReadProcessData};
+    use crate::procfs::ProcfsError;
+    use sn_fake_clock::FakeClock;
+
+    struct PidIOReaderStub {
+        reverted_sequence: Vec<PidIO>,
+    }
+
+    impl PidIOReaderStub {
+        fn new(mut sequence: Vec<PidIO>) -> Self {
+            sequence.reverse();
+
+            PidIOReaderStub {
+                reverted_sequence: sequence,
+            }
+        }
+    }
+
+    impl ReadProcessData<PidIO> for PidIOReaderStub {
+        fn read(&mut self, _pid: Pid) -> Result<PidIO, ProcfsError> {
+            Ok(self
+                .reverted_sequence
+                .pop()
+                .expect("Index error while reading with PidIOReaderStub"))
+        }
+    }
+
+    #[test]
+    fn test_should_calculate_correct_input_rate() {
+        let sequence = vec![PidIO::new(0, 0, 0), PidIO::new(10, 15, 5)];
+        let reader = PidIOReaderStub::new(sequence);
+
+        let mut io_probe = DiskIOProbe::from_reader(Box::new(reader));
+
+        FakeClock::set_time(1000);
+        let io_1 = io_probe.probe(0).unwrap();
+        FakeClock::advance_time(1000);
+        let io_2 = io_probe.probe(0).unwrap();
+
+        assert_eq!(io_1, IOMetric::new(0, 0));
+        assert_eq!(io_2, IOMetric::new(10, 10));
     }
 }

--- a/src/procfs/mod.rs
+++ b/src/procfs/mod.rs
@@ -11,7 +11,7 @@ mod parsers;
 pub mod process;
 
 pub mod cpu_probe;
-// pub mod mem_probe;
+pub mod diskio_probe;
 
 #[cfg(feature = "netio")]
 pub mod net_io_probe;

--- a/src/procfs/mod.rs
+++ b/src/procfs/mod.rs
@@ -15,7 +15,7 @@ pub mod diskio_probe;
 
 #[cfg(feature = "netio")]
 pub mod net_io_probe;
-#[cfg(feature = "netio")]
+
 mod rates;
 
 #[derive(Error, Debug)]

--- a/src/procfs/parsers.rs
+++ b/src/procfs/parsers.rs
@@ -87,7 +87,7 @@ where
     fn get_process_reader(&mut self, pid: Pid) -> Result<&mut ProcfsReader<D>, ProcfsError> {
         Ok(match self.readers.entry(pid) {
             Entry::Occupied(o) => o.into_mut(),
-            Entry::Vacant(v) => v.insert({ ProcfsReader::new(D::filepath(pid).as_path())? }),
+            Entry::Vacant(v) => v.insert(ProcfsReader::new(D::filepath(pid).as_path())?),
         })
     }
 }
@@ -494,12 +494,14 @@ mod test_pid_stat {
     }
 }
 
+#[derive(Eq, PartialEq, Debug, Copy, Clone)]
 pub struct PidIO {
     read_bytes: usize,
     write_bytes: usize,
     cancelled_write_bytes: usize,
 }
 
+/// Represents data from `/proc/[PID]/io`
 impl PidIO {
     pub fn read_bytes(&self) -> usize {
         self.read_bytes
@@ -507,6 +509,17 @@ impl PidIO {
 
     pub fn written_bytes(&self) -> usize {
         self.write_bytes.saturating_sub(self.cancelled_write_bytes)
+    }
+}
+
+#[cfg(test)]
+impl PidIO {
+    pub fn new(read_bytes: usize, write_bytes: usize, cancelled_write_bytes: usize) -> Self {
+        PidIO {
+            read_bytes,
+            write_bytes,
+            cancelled_write_bytes,
+        }
     }
 }
 

--- a/src/procfs/rates.rs
+++ b/src/procfs/rates.rs
@@ -150,13 +150,12 @@ impl ProcessesRates {
 
 #[cfg(test)]
 mod test_process_rates {
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
 
     use rstest::*;
     use sn_fake_clock::FakeClock;
 
     use crate::procfs::rates::{ProcessesRates, PushMode};
-    use crate::procfs::ProcfsError;
 
     #[fixture]
     fn process_rates() -> ProcessesRates {
@@ -165,7 +164,7 @@ mod test_process_rates {
     }
 
     #[rstest]
-    fn test_rate_returns_error_if_pid_not_known(mut process_rates: ProcessesRates) {
+    fn test_rate_returns_error_if_pid_not_known(process_rates: ProcessesRates) {
         assert!(process_rates.rate(123).is_err());
     }
 

--- a/src/procfs/rates.rs
+++ b/src/procfs/rates.rs
@@ -235,7 +235,7 @@ mod test_process_rates {
     }
 
     #[rstest]
-    fn test_should_not_panic_when_range_larger_than_timestamp(mut process_rates: ProcessesRates) {
+    fn test_should_not_panic_when_range_larger_than_now_timestamp() {
         // By default with FakeClock, now() == 0s.
         // We want to make sure that ProcessesRates does not panic when it tries to substract data_retention from now()
         let mut proc_rates = ProcessesRates::new(PushMode::Accumulative, Duration::from_secs(1));


### PR DESCRIPTION
A new metric type is now selectable on the spv application: `Disk I/O`.

Selecting this type of metric displays two lines on the chart: input and output bitrates (in bytes/s).
We use the `read_bytes`, `write_bytes` and `cancelled_write_bytes` lines from `/proc/[pid]/io` to calculate these rates. This means that they correspond only to data that is actually written to or read from the storage layer.