### PR TITLE
List dead processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "simplelog"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59d0fe306a0ced1c88a58042dc22fc2ddd000982c26d75f6aa09a394547c41e0"
+checksum = "85d04ae642154220ef00ee82c36fb07853c10a4f2a0ca6719f9991211d2eb959"
 dependencies = [
  "chrono",
  "log 0.4.11",

--- a/src/core/iteration.rs
+++ b/src/core/iteration.rs
@@ -1,0 +1,91 @@
+/// On every iteration of the application's main loop, all processes will be probed for their metrics
+/// An Iteration value refers to one of these iterations
+pub type Iteration = usize;
+
+// TODO It would be simpler if this were a singleton, no need to pass an `Iteration` value everywhere
+pub struct IterTracker {
+    counter: usize,
+}
+
+impl Default for IterTracker {
+    fn default() -> Self {
+        IterTracker { counter: 0 }
+    }
+}
+
+impl IterTracker {
+    pub fn tick(&mut self) {
+        self.counter += 1
+    }
+
+    pub fn iteration(&self) -> usize {
+        self.counter
+    }
+}
+
+#[cfg(test)]
+mod test_iteration {
+    use rstest::*;
+
+    use crate::core::iteration::IterTracker;
+
+    #[fixture]
+    fn iteration_tracker() -> IterTracker {
+        IterTracker::default()
+    }
+
+    #[rstest]
+    fn test_iteration_should_be_0_by_default(iteration_tracker: IterTracker) {
+        assert_eq!(iteration_tracker.iteration(), 0);
+    }
+
+    #[rstest]
+    #[case(1)]
+    #[case(5)]
+    fn test_iteration_should_increase_on_tick(mut iteration_tracker: IterTracker, #[case] tick_count: usize) {
+        for _ in 0..tick_count {
+            iteration_tracker.tick();
+        }
+
+        assert_eq!(iteration_tracker.iteration(), tick_count);
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct IterSpan {
+    span: usize,
+}
+
+impl Default for IterSpan {
+    fn default() -> Self {
+        IterSpan {
+            span: 60, // Default hard-coded value, at 1 iteration/s, is a span of 1 minute
+        }
+    }
+}
+
+impl IterSpan {
+    #[cfg(test)]
+    pub fn new(span: usize) -> Self {
+        IterSpan { span }
+    }
+
+    pub fn begin(&self, current_iteration: Iteration) -> Iteration {
+        current_iteration.checked_sub(self.span).unwrap_or(Iteration::MIN)
+    }
+
+    pub fn span(&self) -> usize {
+        self.span
+    }
+}
+
+#[cfg(test)]
+mod test_iter_span {
+    use crate::core::iteration::IterSpan;
+
+    #[test]
+    fn test_should_substract_60_iteration_to_get_begin() {
+        let span = IterSpan::default();
+        assert_eq!(span.begin(120), 60);
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -7,6 +7,7 @@ use thiserror::Error;
 use crate::core::process::Pid;
 
 pub mod collection;
+pub mod iteration;
 pub mod metrics;
 pub mod probe;
 pub mod process;

--- a/src/core/process.rs
+++ b/src/core/process.rs
@@ -86,19 +86,6 @@ impl ProcessCollector {
     }
 }
 
-/// Trait with methods to retrieve basic information about running processes
-pub trait ProcessScanner {
-    /// Returns a list containing the PIDs of all currently running processes
-    fn scan(&self) -> Result<Vec<Pid>, Error>;
-
-    /// Returns The ProcessMetadata of the currently running process with the given PID
-    ///
-    /// # Arguments
-    ///
-    /// * `pid`: The process identifier of the currently running process
-    fn fetch_metadata(&self, pid: Pid) -> Result<ProcessMetadata, Error>;
-}
-
 #[cfg(test)]
 mod test_process_collector {
     use crate::core::process::{Pid, ProcessCollector, ProcessMetadata, ProcessScanner};
@@ -172,4 +159,17 @@ mod test_process_collector {
         assert_eq!(processes_pids.len(), 2);
         assert!(!processes_pids.contains(&2))
     }
+}
+
+/// Trait with methods to retrieve basic information about running processes
+pub trait ProcessScanner {
+    /// Returns a list containing the PIDs of all currently running processes
+    fn scan(&mut self) -> Result<Vec<Pid>, Error>;
+
+    /// Returns The ProcessMetadata of the currently running process with the given PID
+    ///
+    /// # Arguments
+    ///
+    /// * `pid`: The process identifier of the currently running process
+    fn fetch_metadata(&self, pid: Pid) -> Result<ProcessMetadata, Error>;
 }

--- a/src/core/process.rs
+++ b/src/core/process.rs
@@ -1,6 +1,7 @@
 //! Process discovery utilities
 
 use std::collections::HashMap;
+use std::fmt::{Display, Formatter};
 
 use log::warn;
 
@@ -23,6 +24,15 @@ pub struct ProcessMetadata {
 pub enum Status {
     RUNNING,
     DEAD,
+}
+
+impl Display for Status {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Status::RUNNING => f.write_str("running"),
+            Status::DEAD => f.write_str("dead")
+        }
+    }
 }
 
 /// Describes a process

--- a/src/core/process.rs
+++ b/src/core/process.rs
@@ -1,5 +1,7 @@
 //! Process discovery utilities
 
+use std::collections::HashMap;
+
 use log::warn;
 
 use crate::core::Error;
@@ -14,6 +16,13 @@ pub type Pid = u32; // TODO add new type UPID (Unique PID) through the entire ex
 pub struct ProcessMetadata {
     pid: Pid,
     command: String,
+    status: Status,
+}
+
+#[derive(Eq, PartialEq, Debug, Copy, Clone)]
+pub enum Status {
+    RUNNING,
+    DEAD,
 }
 
 /// Describes a process
@@ -26,6 +35,7 @@ impl ProcessMetadata {
         ProcessMetadata {
             pid,
             command: command.into(),
+            status: Status::RUNNING,
         }
     }
 
@@ -42,11 +52,21 @@ impl ProcessMetadata {
     pub fn command(&self) -> &str {
         self.command.as_str()
     }
+
+    /// Returns the status of the process, indicating if it is still running or not
+    pub fn status(&self) -> Status {
+        self.status
+    }
+
+    /// Marks a process as dead, indicating that it is not running anymore
+    pub fn set_dead(&mut self) {
+        self.status = Status::DEAD
+    }
 }
 
 #[cfg(test)]
 mod test_process_metadata {
-    use crate::core::process::ProcessMetadata;
+    use crate::core::process::{ProcessMetadata, Status};
 
     #[test]
     fn test_pid_should_be_pm_pid() {
@@ -57,24 +77,51 @@ mod test_process_metadata {
     fn test_command_should_be_pm_command() {
         assert_eq!(ProcessMetadata::new(123, "command").command(), "command");
     }
+
+    #[test]
+    fn test_status_should_be_running_by_default() {
+        assert_eq!(ProcessMetadata::new(123, "command").status(), Status::RUNNING);
+    }
+
+    #[test]
+    fn test_status_should_be_dead_once_marked_as_dead() {
+        let mut pm = ProcessMetadata::new(123, "command");
+        pm.set_dead();
+        assert_eq!(pm.status(), Status::RUNNING);
+    }
 }
 
 /// Collects the running processes
 pub struct ProcessCollector {
     scanner: Box<dyn ProcessScanner>,
+    registered_processes: HashMap<Pid, ProcessMetadata>,
 }
 
 impl ProcessCollector {
     pub fn new(scanner: Box<dyn ProcessScanner>) -> Self {
-        Self { scanner }
+        Self {
+            scanner,
+            registered_processes: HashMap::new(),
+        }
     }
 
-    /// Returns a Vec of [`ProcessMetadata`](struct.ProcessMetadata), each corresponding to a running process
-    pub fn processes(&self) -> Result<Vec<ProcessMetadata>, Error> {
-        let pids = self.scanner.scan()?;
+    /// Returns a Vec of [`ProcessMetadata`](struct.ProcessMetadata), each corresponding to process (running or dead)
+    pub fn collect_processes(&mut self) -> Result<Vec<ProcessMetadata>, Error> {
+        let running_pids = self.scanner.scan()?;
 
-        Ok(pids
+        self.mark_dead_processes(&running_pids);
+
+        for pm in self.parse_new_processes(&running_pids) {
+            self.registered_processes.insert(pm.pid(), pm);
+        }
+
+        Ok(self.registered_processes.values().map(|pm| pm.clone()).collect())
+    }
+
+    fn parse_new_processes(&self, running_pids: &[Pid]) -> Vec<ProcessMetadata> {
+        running_pids
             .iter()
+            .filter(|p| !self.registered_processes.contains_key(*p))
             .filter_map(|pid| match self.scanner.fetch_metadata(*pid) {
                 Err(e) => {
                     warn!("Error fetching process metadata: {:?}", e);
@@ -82,24 +129,51 @@ impl ProcessCollector {
                 }
                 Ok(pm) => Some(pm),
             })
-            .collect())
+            .collect()
+    }
+
+    fn mark_dead_processes(&mut self, running_pids: &Vec<Pid>) {
+        self.registered_processes
+            .values_mut()
+            .filter(|pm| !running_pids.contains(&pm.pid()))
+            .for_each(|pm| pm.set_dead());
     }
 }
 
 #[cfg(test)]
 mod test_process_collector {
-    use crate::core::process::{Pid, ProcessCollector, ProcessMetadata, ProcessScanner};
+    use crate::core::process::{Pid, ProcessCollector, ProcessMetadata, ProcessScanner, Status};
     use crate::core::Error;
     use crate::core::Error::InvalidPID;
 
     struct ScannerStub {
-        scanned_pids: Vec<Pid>,
+        scan_count: usize,
+        scanned_pids: Vec<Vec<Pid>>,
         failing_processes: Vec<Pid>,
     }
 
+    impl ScannerStub {
+        fn new(scanned_pids: Vec<Pid>) -> Self {
+            Self::new_with_failing_processes(scanned_pids, vec![])
+        }
+
+        fn new_with_failing_processes(scanned_pids: Vec<Pid>, failing_processes: Vec<Pid>) -> Self {
+            ScannerStub {
+                scan_count: 0,
+                scanned_pids: vec![scanned_pids],
+                failing_processes,
+            }
+        }
+
+        fn set_next_scanned_pids(&mut self, scanned_pids: Vec<Pid>) {
+            self.scanned_pids.push(scanned_pids);
+        }
+    }
+
     impl ProcessScanner for ScannerStub {
-        fn scan(&self) -> Result<Vec<Pid>, Error> {
-            Ok(self.scanned_pids.clone())
+        fn scan(&mut self) -> Result<Vec<Pid>, Error> {
+            self.scan_count += 1;
+            Ok(self.scanned_pids[self.scan_count - 1].clone())
         }
 
         fn fetch_metadata(&self, pid: Pid) -> Result<ProcessMetadata, Error> {
@@ -112,32 +186,29 @@ mod test_process_collector {
     }
 
     fn build_process_collector(scanned_pids: Vec<Pid>) -> ProcessCollector {
-        let boxed_scanner = Box::new(ScannerStub {
-            scanned_pids,
-            failing_processes: vec![],
-        });
+        let boxed_scanner = Box::new(ScannerStub::new(scanned_pids));
         ProcessCollector::new(boxed_scanner)
     }
 
-    fn build_failing_process_collector(scanned_pids: Vec<Pid>, failing_processes: Vec<Pid>) -> ProcessCollector {
-        let boxed_scanner = Box::new(ScannerStub {
-            scanned_pids,
-            failing_processes,
-        });
+    fn build_collector_which_fails(scanned_pids: Vec<Pid>, failing_processes: Vec<Pid>) -> ProcessCollector {
+        let boxed_scanner = Box::new(ScannerStub::new_with_failing_processes(scanned_pids, failing_processes));
         ProcessCollector::new(boxed_scanner)
     }
 
     #[test]
     fn test_should_collect_no_process_when_no_pid_scanned() {
-        let collector = build_process_collector(vec![]);
-        assert_eq!(collector.processes().unwrap(), vec![]);
+        let mut collector = build_process_collector(vec![]);
+
+        let procesess = collector.collect_processes().unwrap();
+
+        assert_eq!(procesess, vec![]);
     }
 
     #[test]
     fn test_should_collect_processes_when_pids_are_scanned() {
         let scanned_pids = vec![1, 2, 3];
-        let collector = build_process_collector(scanned_pids.clone());
-        let processes = collector.processes().unwrap();
+        let mut collector = build_process_collector(scanned_pids.clone());
+        let processes = collector.collect_processes().unwrap();
 
         assert_eq!(processes.len(), 3);
 
@@ -149,15 +220,35 @@ mod test_process_collector {
 
     #[test]
     fn test_should_ignore_processes_for_which_scanning_fails() {
-        let scanned_pids = vec![1, 2, 3];
-        let failing_processes = vec![2];
-        let collector = build_failing_process_collector(scanned_pids, failing_processes);
-        let processes = collector.processes().unwrap();
+        let mut collector = build_collector_which_fails(vec![1, 2, 3], vec![2]);
+        let processes = collector.collect_processes().unwrap();
 
         let processes_pids = processes.iter().map(|pm| pm.pid).collect::<Vec<Pid>>();
 
         assert_eq!(processes_pids.len(), 2);
         assert!(!processes_pids.contains(&2))
+    }
+
+    #[test]
+    fn test_should_set_status_of_running_processes_to_running() {
+        let mut collector = build_process_collector(vec![1]);
+
+        let processes = collector.collect_processes().unwrap();
+
+        assert_eq!(processes[0].status, Status::RUNNING);
+    }
+
+    #[test]
+    fn test_should_mark_dead_process_as_dead() {
+        let mut boxed_scanner = Box::new(ScannerStub::new(vec![3]));
+        boxed_scanner.set_next_scanned_pids(vec![]);
+
+        let mut collector = ProcessCollector::new(boxed_scanner);
+
+        collector.collect_processes().unwrap(); // Process pid=3 is collected
+        let processes = collector.collect_processes().unwrap(); // Process pid=3 is not running anymore
+
+        assert_eq!(processes[0].status, Status::DEAD);
     }
 }
 

--- a/src/core/view.rs
+++ b/src/core/view.rs
@@ -2,14 +2,8 @@
 
 use std::cmp::Ordering;
 use std::collections::HashMap;
-use std::time::Duration;
 
-#[cfg(not(test))]
-use std::time::Instant;
-
-#[cfg(test)]
-use sn_fake_clock::FakeClock as Instant;
-
+use crate::core::iteration::{IterSpan, Iteration};
 use crate::core::metrics::Metric;
 use crate::core::process::Pid;
 
@@ -17,62 +11,39 @@ use crate::core::process::Pid;
 ///
 /// Refer to the [`MetricCollector`](crate::core::collection::MetricCollector) trait to instanciate a `MetricView`
 pub struct MetricView<'a> {
-    last_metric_date: Instant,
     metrics: Vec<&'a dyn Metric>,
-    resolution: Duration,
     default: &'a dyn Metric,
+    span: IterSpan,
+    last_metric_iteration: Iteration,
+    current_iteration: Iteration,
 }
 
 impl<'a> MetricView<'a> {
     pub(crate) fn new(
         metrics: Vec<&'a dyn Metric>,
-        last_metric_date: Instant,
-        resolution: Duration,
         default: &'a dyn Metric,
+        span: IterSpan,
+        last_metric_iteration: Iteration,
+        current_iteration: Iteration,
     ) -> Self {
         Self {
             metrics,
-            last_metric_date,
-            resolution,
             default,
+            span,
+            last_metric_iteration,
+            current_iteration,
         }
     }
 
     /// Returns a slice of the metrics contained in this view.
     /// The slice only covers the last metrics covered by the `span` parameter.
-    ///
-    /// For example, if the view has a resolution of 1 second, `extract(Duration::from_secs(10))`
-    /// will return the last 10 metrics.
-    ///
-    /// # Arguments
-    ///  * span: Indicates from how long ago the metrics should be compared
-    pub fn extract(&'a self, span: Duration) -> &[&'a dyn Metric] {
-        let collected_metrics_count = self.metrics.len();
-        let expected_metrics_count = self.calculate_number_of_expected_metrics(span);
-        let skipped_metrics = collected_metrics_count.saturating_sub(expected_metrics_count);
-
-        &self.metrics[skipped_metrics..]
-    }
-
-    /// Indicates how many metrics should be returned by extract() with the given span, according
-    /// to this view's resolution.
-    /// Note that the value returned by this function is only an upper bound.
-    /// `self.extract()` may return less metrics.
-    ///
-    /// # Arguments
-    ///  * span: Indicates from how long ago should metrics be returned
-    fn calculate_number_of_expected_metrics(&self, span: Duration) -> usize {
-        (span.as_secs() / self.resolution.as_secs()) as usize
+    pub fn as_slice(&'a self) -> &[&'a dyn Metric] {
+        &self.metrics
     }
 
     /// Returns the unit representation of the metrics contained in this view
     pub fn unit(&self) -> &'static str {
         self.default.unit()
-    }
-
-    /// Indicates the `Duration` step between each metric
-    pub fn resolution(&self) -> Duration {
-        self.resolution
     }
 
     /// Returns the latest collected metric, or its default value if no metric has
@@ -89,8 +60,8 @@ impl<'a> MetricView<'a> {
     ///
     /// # Arguments
     ///  * span: Indicates from how long ago the metrics should be compared
-    pub fn max_f64(&self, span: Duration) -> f64 {
-        self.max_metric(span).max_value()
+    pub fn max_f64(&self) -> f64 {
+        self.max_metric().max_value()
     }
 
     /// Returns a concise representation of the greatest metric in the given span. See [`MetricView::new()`](#method.extract) for
@@ -101,13 +72,13 @@ impl<'a> MetricView<'a> {
     ///
     /// # Arguments
     ///  * span: Indicates from how long ago the metrics should be compared
-    pub fn max_concise_repr(&self, span: Duration) -> String {
-        self.max_metric(span).concise_repr()
+    pub fn max_concise_repr(&self) -> String {
+        self.max_metric().concise_repr()
     }
 
-    fn max_metric(&self, span: Duration) -> &dyn Metric {
+    fn max_metric(&self) -> &dyn Metric {
         *(self
-            .extract(span)
+            .metrics
             .iter()
             .max_by(|m1, m2| {
                 let v1 = m1.max_value();
@@ -118,11 +89,17 @@ impl<'a> MetricView<'a> {
             .unwrap_or(&self.default))
     }
 
+    pub fn span(&self) -> usize {
+        self.span.span()
+    }
+
     /// Indicates from when dates the last metric in this view
-    pub fn last_metric_date(&self) -> Instant {
-        // TODO in core/spv/ui, keep track of time using iteration counter instead of actual Instant instances
-        //   only pulse.rs should keep track of time.
-        self.last_metric_date
+    pub fn last_iteration(&self) -> Iteration {
+        self.last_metric_iteration
+    }
+
+    pub fn current_iteration(&self) -> Iteration {
+        self.current_iteration
     }
 }
 
@@ -156,23 +133,15 @@ impl<'a> MetricsOverview<'a> {
 
 #[cfg(test)]
 mod test_metric_view {
-    use sn_fake_clock::FakeClock;
-    use std::time::Duration;
-
     use crate::core::collection::MetricCollection;
+    use crate::core::iteration::IterSpan;
     use crate::core::metrics::{Metric, PercentMetric};
-    use crate::core::process::ProcessMetadata;
     use crate::core::view::test_helpers::produce_metrics_collection;
-    use crate::core::view::MetricView;
-
-    fn build_view_of_pid_0(collection: &MetricCollection<PercentMetric>) -> MetricView {
-        collection.view(ProcessMetadata::new(0, "cmd"), Duration::from_secs(1))
-    }
 
     #[test]
     fn test_last_or_default_should_be_latest_metric_when_exists() {
         let collection = produce_metrics_collection(1, vec![0., 1.]);
-        let view = build_view_of_pid_0(&collection);
+        let view = collection.view(0, IterSpan::default(), 10);
 
         assert_eq!(view.last_or_default(), &PercentMetric::new(1.));
     }
@@ -180,7 +149,7 @@ mod test_metric_view {
     #[test]
     fn test_last_or_default_should_be_default_when_pid_unknown() {
         let collection = MetricCollection::<PercentMetric>::new();
-        let view = build_view_of_pid_0(&collection);
+        let view = collection.view(0, IterSpan::default(), 10);
 
         assert_eq!(view.last_or_default(), &PercentMetric::default());
     }
@@ -188,53 +157,42 @@ mod test_metric_view {
     #[test]
     fn test_unit_should_be_metric_unit() {
         let collection = MetricCollection::<PercentMetric>::new();
-        let view = build_view_of_pid_0(&collection);
+        let view = collection.view(0, IterSpan::default(), 10);
 
         assert_eq!(view.unit(), PercentMetric::default().unit());
     }
 
     #[test]
-    fn test_resolution_should_return_resolution_given_in_constructor() {
-        let collection = MetricCollection::<PercentMetric>::new();
-        let view = collection.view(ProcessMetadata::new(1, "cmd"), Duration::from_secs(123));
-
-        assert_eq!(view.resolution(), Duration::from_secs(123));
-    }
-
-    #[test]
     fn test_extract_should_extract_nothing_if_collection_is_empty() {
         let collection = MetricCollection::<PercentMetric>::new();
-        let view = build_view_of_pid_0(&collection);
+        let view = collection.view(0, IterSpan::default(), 10);
 
-        assert_eq!(view.extract(Duration::from_secs(60)), &[]);
+        assert_eq!(view.as_slice(), &[]);
     }
 
     #[test]
-    fn test_extract_should_return_only_last_metric_if_span_equals_duration() {
+    fn test_extract_should_return_only_last_metric_if_span_coveres_1_iteration() {
         let collection = produce_metrics_collection(1, vec![0., 1.]);
-        let view = build_view_of_pid_0(&collection);
+        let view = collection.view(0, IterSpan::new(1), 10);
 
-        assert_eq!(view.extract(view.resolution()), &[view.last_or_default()]);
+        assert_eq!(view.as_slice(), &[view.last_or_default()]);
     }
 
     #[test]
-    fn test_extract_should_return_two_last_metric_if_span_is_double_duration() {
+    fn test_extract_should_return_two_last_metric_if_span_covers_2_iterations() {
         let collection = produce_metrics_collection(1, vec![0., 1., 2., 3.]);
-        let view = build_view_of_pid_0(&collection);
-
-        let extract = view.extract(view.resolution() * 2);
+        let view = collection.view(0, IterSpan::new(2), 10);
 
         let expected: &[&dyn Metric; 2] = &[&PercentMetric::new(2.), &PercentMetric::new(3.)];
 
-        assert_eq!(extract, expected);
+        assert_eq!(view.as_slice(), expected);
     }
 
     #[test]
     fn test_should_only_return_existing_items_when_span_greater_than_metric_count() {
         let collection = produce_metrics_collection(1, vec![0., 1., 2.]);
-        let view = build_view_of_pid_0(&collection);
-
-        let extract = view.extract(view.resolution() * 20);
+        let view = collection.view(0, IterSpan::new(20), 10);
+        let extract = view.as_slice();
 
         assert_eq!(extract.len(), 3);
         assert_eq!(extract[0], &PercentMetric::new(0.));
@@ -244,41 +202,61 @@ mod test_metric_view {
     #[test]
     fn test_max_f64_should_return_max_value() {
         let collection = produce_metrics_collection(1, vec![10., 0., 2.]);
-        let view = build_view_of_pid_0(&collection);
+        let view = collection.view(0, IterSpan::default(), 10);
 
-        assert_eq!(view.max_f64(Duration::from_secs(3)), 10.);
+        assert_eq!(view.max_f64(), 10.);
     }
 
     #[test]
     fn test_max_f64_should_not_return_values_out_of_span() {
         let collection = produce_metrics_collection(1, vec![10., 0., 2.]);
-        let view = build_view_of_pid_0(&collection);
+        let view = collection.view(0, IterSpan::new(2), 10);
 
-        assert_eq!(view.max_f64(Duration::from_secs(2)), 2.);
+        assert_eq!(view.max_f64(), 2.);
     }
 
     #[test]
     fn test_max_f64_should_return_0_when_empty() {
         let collection = MetricCollection::<PercentMetric>::new();
-        let view = build_view_of_pid_0(&collection);
+        let view = collection.view(0, IterSpan::default(), 10);
 
-        assert_eq!(view.max_f64(Duration::from_secs(2)), 0.);
+        assert_eq!(view.max_f64(), 0.);
     }
 
     #[test]
     fn test_max_repr_should_return_repr_of_max_value() {
         let collection = produce_metrics_collection(1, vec![0., 10., 2.]);
-        let view = build_view_of_pid_0(&collection);
+        let view = collection.view(0, IterSpan::default(), 10);
 
-        assert_eq!(view.max_concise_repr(Duration::from_secs(3)), "10.0".to_string());
+        assert_eq!(view.max_concise_repr(), "10.0".to_string());
     }
 
     #[test]
-    fn test_should_return_last_metric_date() {
-        let now = FakeClock::now();
-        let default = PercentMetric::new(0.);
-        let mv = MetricView::new(vec![], now, Duration::from_secs(1), &default);
-        assert_eq!(mv.last_metric_date(), now);
+    fn test_should_return_0_as_default_last_iteration() {
+        let collection = MetricCollection::<PercentMetric>::new();
+
+        let view = collection.view(1, IterSpan::default(), 10);
+        assert_eq!(view.last_iteration(), 0);
+    }
+
+    #[test]
+    fn test_should_return_last_iteration() {
+        let mut collection = MetricCollection::new();
+        collection.push(1, PercentMetric::new(10.), 1);
+        collection.push(1, PercentMetric::new(10.), 2);
+
+        let view = collection.view(1, IterSpan::default(), 10);
+        assert_eq!(view.last_iteration(), 2);
+    }
+
+    #[test]
+    fn test_should_return_correct_span() {
+        let mut collection = MetricCollection::new();
+        collection.push(1, PercentMetric::new(10.), 1);
+        collection.push(1, PercentMetric::new(10.), 2);
+
+        let view = collection.view(1, IterSpan::new(123), 10);
+        assert_eq!(view.span(), 123);
     }
 }
 
@@ -330,9 +308,9 @@ mod test_helpers {
     pub(crate) fn produce_metrics_collection(proc_count: usize, values: Vec<f64>) -> MetricCollection<PercentMetric> {
         let mut collection = MetricCollection::new();
 
-        for value in values.into_iter() {
+        for (iteration, value) in values.into_iter().enumerate() {
             for proc_idx in 0..proc_count {
-                collection.push(proc_idx as Pid, PercentMetric::new(value));
+                collection.push(proc_idx as Pid, PercentMetric::new(value), iteration);
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ fn main() -> anyhow::Result<()> {
     let process_scanner = ProcfsScanner::new();
     let process_view = ProcessCollector::new(Box::new(process_scanner));
 
-    let collectors = build_collectors(refresh_period)?;
+    let collectors = build_collectors()?;
 
     let app = SpvApplication::new(rx, collectors, process_view)?;
     app.run()?;
@@ -62,21 +62,21 @@ fn init_logging() {
     WriteLogger::init(LevelFilter::Debug, log_config, log_file).expect("Could not initialize logging");
 }
 
-fn build_collectors(resolution: Duration) -> Result<Vec<Box<dyn MetricCollector>>, Error> {
+fn build_collectors() -> Result<Vec<Box<dyn MetricCollector>>, Error> {
     let mut collectors = vec![];
 
     let cpu_probe = CpuProbe::new().map_err(Error::CoreError)?;
-    let cpu_collector = ProbeCollector::new(cpu_probe, resolution);
+    let cpu_collector = ProbeCollector::new(cpu_probe);
     collectors.push(Box::new(cpu_collector) as Box<dyn MetricCollector>);
 
     let disk_io_probe = DiskIOProbe::default();
-    let disk_io_collector = ProbeCollector::new(disk_io_probe, resolution);
+    let disk_io_collector = ProbeCollector::new(disk_io_probe);
     collectors.push(Box::new(disk_io_collector) as Box<dyn MetricCollector>);
 
     #[cfg(feature = "netio")]
     {
         let netio_probe = NetIoProbe::new().map_err(Error::CoreError)?;
-        let net_collector = ProbeCollector::new(netio_probe, resolution);
+        let net_collector = ProbeCollector::new(netio_probe);
         collectors.push(Box::new(net_collector) as Box<dyn MetricCollector>);
     }
 

--- a/src/procfs/process.rs
+++ b/src/procfs/process.rs
@@ -61,7 +61,7 @@ impl ProcfsScanner {
 
 impl ProcessScanner for ProcfsScanner {
     /// Returns the PIDs of currently running processes
-    fn scan(&self) -> std::result::Result<Vec<Pid>, CoreError> {
+    fn scan(&mut self) -> std::result::Result<Vec<Pid>, CoreError> {
         let path = self.proc_dir.as_path();
 
         let dir_iter = read_dir(path).map_err(|e| Error::ProcessScanningFailure(path.into(), e))?;
@@ -190,7 +190,7 @@ mod test_pid_scanner {
             );
         }
 
-        let proc_scanner = ProcfsScanner {
+        let mut proc_scanner = ProcfsScanner {
             proc_dir: test_proc_dir.path().to_path_buf(),
         };
 
@@ -208,7 +208,7 @@ mod test_pid_scanner {
         let test_proc_dir = tempdir().expect("Could not create tmp dir");
         set_dir_permissions(test_proc_dir.path(), 0o000).expect("Could not set dir permissions");
 
-        let proc_scanner = ProcfsScanner {
+        let mut proc_scanner = ProcfsScanner {
             proc_dir: test_proc_dir.path().to_path_buf(),
         };
 

--- a/src/spv.rs
+++ b/src/spv.rs
@@ -66,7 +66,7 @@ impl SpvApplication {
 
     fn calibrate_probes(&mut self) -> Result<(), Error> {
         self.collect_running_processes()?;
-        let pids = SpvApplication::extract_processes_pids(&self.process_view.running_processes());
+        let pids = Self::extract_processes_pids(&self.process_view.running_processes());
 
         for c in self.collectors.values_mut() {
             c.calibrate(&pids)?;
@@ -77,7 +77,7 @@ impl SpvApplication {
 
     fn collect_metrics(&mut self) -> Result<(), Error> {
         self.collect_running_processes()?;
-        let running_pids = SpvApplication::extract_processes_pids(&self.process_view.running_processes());
+        let running_pids = Self::extract_processes_pids(&self.process_view.running_processes());
 
         for collector in self.collectors.values_mut() {
             collector.collect(&running_pids).unwrap_or_else(|e| {
@@ -114,12 +114,16 @@ impl SpvApplication {
     }
 
     fn draw_ui(&mut self) -> Result<(), Error> {
-        let selected_pid = self.ui.current_process().map_or(0, |pm| pm.pid());
-
         let current_collector = self.current_collector(&self.collectors);
 
+        let current_process = self
+            .ui
+            .current_process()
+            .cloned()
+            .unwrap_or(ProcessMetadata::new(0, "default"));
+
         self.ui
-            .render(&current_collector.overview(), &current_collector.view(selected_pid))
+            .render(&current_collector.overview(), &current_collector.view(current_process))
             .map_err(Error::UiError)
     }
 

--- a/src/spv.rs
+++ b/src/spv.rs
@@ -95,7 +95,7 @@ impl SpvApplication {
     }
 
     fn collect_processes(&mut self) -> Result<Vec<ProcessMetadata>, Error> {
-        self.process_view.processes().map_err(Error::CoreError)
+        self.process_view.collect_processes().map_err(Error::CoreError)
     }
 
     fn extract_processes_pids(processes: &[ProcessMetadata]) -> Vec<u32> {

--- a/src/ui/chart.rs
+++ b/src/ui/chart.rs
@@ -1,15 +1,14 @@
 use std::time::Duration;
-use tui::layout::Rect;
-use tui::style::{Color, Style};
-use tui::text::Span;
-use tui::widgets::{Axis, Block, Borders, Chart, Dataset, GraphType};
-use tui::{symbols, Frame};
-
 #[cfg(not(test))]
 use std::time::Instant;
 
 #[cfg(test)]
 use sn_fake_clock::FakeClock as Instant;
+use tui::layout::Rect;
+use tui::style::{Color, Style};
+use tui::text::Span;
+use tui::widgets::{Axis, Block, Borders, Chart, Dataset, GraphType};
+use tui::{symbols, Frame};
 
 use crate::core::view::MetricView;
 use crate::ui::terminal::TuiBackend;
@@ -69,7 +68,12 @@ impl MetricsChart {
     }
 
     fn build_y_axis_labels<'a>(upper_bound_repr: String) -> Vec<Span<'a>> {
-        return vec![Span::from("0"), Span::from(upper_bound_repr)];
+        vec![Span::from("0"), Span::from(upper_bound_repr)]
+    }
+
+    pub fn left_bound(&self) -> Instant {
+        // TODO use iteration rather than instant before allowing user to change span
+        Instant::now().checked_sub(self.span).unwrap()
     }
 }
 

--- a/src/ui/chart.rs
+++ b/src/ui/chart.rs
@@ -1,9 +1,3 @@
-use std::time::Duration;
-#[cfg(not(test))]
-use std::time::Instant;
-
-#[cfg(test)]
-use sn_fake_clock::FakeClock as Instant;
 use tui::layout::Rect;
 use tui::style::{Color, Style};
 use tui::text::Span;
@@ -13,38 +7,29 @@ use tui::{symbols, Frame};
 use crate::core::view::MetricView;
 use crate::ui::terminal::TuiBackend;
 
-pub struct MetricsChart {
-    // The time span the chart covers
-    span: Duration,
-    axis_origin_label: String,
+pub struct MetricsChart {}
+
+impl Default for MetricsChart {
+    fn default() -> Self {
+        MetricsChart {}
+    }
 }
 
-// TODO Keep displaying "dead" processes if they are covered by `span`
 impl MetricsChart {
-    pub fn new(span: Duration) -> Self {
-        Self {
-            span,
-            axis_origin_label: "-1m".to_string(), // TODO make this actually reflect self.span
-        }
-    }
-
+    // TODO refactor frame and chunk are always passed together. Merge them in a struct with a render_widget method
     pub fn render(&self, frame: &mut Frame<TuiBackend>, chunk: Rect, metrics_view: &MetricView) {
-        let data_frame = DataFrame::new(metrics_view, self.span);
+        let data_frame = DataFrame::new(metrics_view);
 
         let chart = Chart::new(data_frame.datasets())
             .block(Block::default().borders(Borders::ALL))
-            .x_axis(self.define_x_axis())
-            .y_axis(self.define_y_axis(
-                &data_frame,
-                metrics_view.max_concise_repr(self.span),
-                metrics_view.unit(),
-            ));
+            .x_axis(self.define_x_axis(metrics_view))
+            .y_axis(self.define_y_axis(&data_frame, metrics_view.max_concise_repr(), metrics_view.unit()));
 
         frame.render_widget(chart, chunk);
     }
 
-    fn define_x_axis(&self) -> Axis {
-        let labels = [&self.axis_origin_label, "now"]
+    fn define_x_axis(&self, metrics_view: &MetricView) -> Axis {
+        let labels = ["-1m", "now"] // TODO make this actually reflect metrics_view
             .iter()
             .cloned()
             .map(Span::from)
@@ -52,7 +37,10 @@ impl MetricsChart {
 
         Axis::default()
             .style(Style::default().fg(Color::White))
-            .bounds([0. - self.span.as_secs_f64(), 0.0])
+            .bounds([
+                metrics_view.current_iteration() as f64 - metrics_view.span() as f64,
+                metrics_view.current_iteration() as f64,
+            ])
             .labels(labels)
     }
 
@@ -70,28 +58,22 @@ impl MetricsChart {
     fn build_y_axis_labels<'a>(upper_bound_repr: String) -> Vec<Span<'a>> {
         vec![Span::from("0"), Span::from(upper_bound_repr)]
     }
-
-    pub fn left_bound(&self) -> Instant {
-        // TODO use iteration rather than instant before allowing user to change span
-        Instant::now().checked_sub(self.span).unwrap()
-    }
 }
 
+// TODO refactor - DataFrame does not need to be an object. Replace it by functions / and test them
 /// Performs all required operations to get raw "drawable" data from `&[&Metric]`
 struct DataFrame<'a> {
     metrics_view: &'a MetricView<'a>,
     // data has to be persisted as an attr, to be able to return a Dataset which references data
     // from this vec
     data: Vec<Vec<(f64, f64)>>,
-    span: Duration,
 }
 
 impl<'a> DataFrame<'a> {
-    pub fn new(metrics_view: &'a MetricView, span: Duration) -> Self {
+    pub fn new(metrics_view: &'a MetricView) -> Self {
         Self {
             metrics_view,
-            data: Self::extract_raw_from_metrics(metrics_view, span, metrics_view.resolution()),
-            span,
+            data: Self::extract_raw_from_metrics(metrics_view),
         }
     }
 
@@ -126,24 +108,21 @@ impl<'a> DataFrame<'a> {
     /// Extract raw data from a collection of metrics
     /// Raw data consists of sets of (f64, f64) tuples, each set corresponding to a drawable
     /// `Dataset`
-    fn extract_raw_from_metrics(metrics_view: &MetricView, span: Duration, step: Duration) -> Vec<Vec<(f64, f64)>> {
+    fn extract_raw_from_metrics(metrics_view: &MetricView) -> Vec<Vec<(f64, f64)>> {
         let mut data_vecs: Vec<_> = Vec::new();
         let metrics_cardinality = metrics_view.last_or_default().cardinality();
 
-        // TODO use iteration count rather than relying on timestamps
-        let age_of_metrics = Instant::now().duration_since(metrics_view.last_metric_date()).as_secs() as f64;
+        let last_iter = metrics_view.last_iteration();
 
         for dimension_idx in 0..metrics_cardinality {
             let data: Vec<_> = metrics_view
-                .extract(span)
+                .as_slice()
                 .iter()
                 .rev()
                 .map(|m| m.as_f64(dimension_idx).expect("Error accessing raw metric value"))
                 .enumerate()
-                .map(|(idx, raw_value)| {
-                    let delta_from_origin = age_of_metrics + idx as f64 * step.as_secs_f64();
-                    (0. - delta_from_origin, raw_value)
-                })
+                .map(|(idx, raw_value)| ((last_iter - idx) as f64, raw_value))
+                .rev()
                 .collect();
 
             data_vecs.push(data);
@@ -153,6 +132,6 @@ impl<'a> DataFrame<'a> {
     }
 
     pub fn max_value(&self) -> f64 {
-        self.metrics_view.max_f64(self.span)
+        self.metrics_view.max_f64()
     }
 }

--- a/src/ui/metadata.rs
+++ b/src/ui/metadata.rs
@@ -25,7 +25,7 @@ impl MetadataBar {
             None => "No process is currently selected".to_string(),
             Some(pm) => {
                 format!("{} ({}) - {}", pm.pid(), pm.status(), pm.command())
-            },
+            }
         }
     }
 

--- a/src/ui/metadata.rs
+++ b/src/ui/metadata.rs
@@ -23,7 +23,9 @@ impl MetadataBar {
     fn build_text(process: Option<&ProcessMetadata>) -> String {
         match process.as_ref() {
             None => "No process is currently selected".to_string(),
-            Some(pm) => format!("{} - {}", pm.pid(), pm.command()),
+            Some(pm) => {
+                format!("{} ({}) - {}", pm.pid(), pm.status(), pm.command())
+            },
         }
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use thiserror::Error;
 
 use crate::core::process::ProcessMetadata;
-use crate::core::view::{MetricView, MetricsOverview};
+use crate::core::view::{MetricsOverview, MetricView};
 use crate::ui::chart::MetricsChart;
 use crate::ui::layout::UiLayout;
 use crate::ui::metadata::MetadataBar;
@@ -48,21 +48,15 @@ impl SpvUI {
     }
 
     pub fn render(&mut self, metrics_overview: &MetricsOverview, metrics_view: &MetricView) -> Result<(), Error> {
-        // We need to do this because the borrow checker does not like having &self.foo in a closure
-        // while borrowing &mut self.terminal
-        let tabs = &self.tabs;
-        let process_list = &mut self.process_list;
-        let chart = &self.chart;
-        let metadata_bar = &self.metadata_bar;
-
         self.terminal.draw(|mut frame| {
             let layout = UiLayout::new(frame);
 
-            tabs.render(&mut frame, layout.tabs_chunk());
+            self.tabs.render(&mut frame, layout.tabs_chunk());
 
-            process_list.render(&mut frame, layout.processes_chunk(), metrics_overview);
-            chart.render(&mut frame, layout.chart_chunk(), metrics_view);
-            metadata_bar.render(&mut frame, layout.metadata_chunk());
+            self.process_list
+                .render(&mut frame, layout.processes_chunk(), metrics_overview);
+            self.chart.render(&mut frame, layout.chart_chunk(), metrics_view);
+            self.metadata_bar.render(&mut frame, layout.metadata_chunk());
         })
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,5 +1,4 @@
 use std::io;
-use std::time::{Duration, Instant};
 
 use thiserror::Error;
 
@@ -36,13 +35,12 @@ pub struct SpvUI {
 impl SpvUI {
     pub fn new(labels: impl Iterator<Item = String>) -> Result<Self, Error> {
         let tabs = MetricTabs::new(labels.collect());
-        let chart = MetricsChart::new(Duration::from_secs(60));
 
         Ok(Self {
             terminal: Terminal::new()?,
             tabs,
             process_list: ProcessList::default(),
-            chart,
+            chart: MetricsChart::default(),
             metadata_bar: MetadataBar::default(),
         })
     }
@@ -89,9 +87,5 @@ impl SpvUI {
 
     pub fn previous_tab(&mut self) {
         self.tabs.previous();
-    }
-
-    pub fn chart_left_bound(&self) -> Instant {
-        self.chart.left_bound()
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,10 +1,10 @@
 use std::io;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use thiserror::Error;
 
 use crate::core::process::ProcessMetadata;
-use crate::core::view::{MetricsOverview, MetricView};
+use crate::core::view::{MetricView, MetricsOverview};
 use crate::ui::chart::MetricsChart;
 use crate::ui::layout::UiLayout;
 use crate::ui::metadata::MetadataBar;
@@ -89,5 +89,9 @@ impl SpvUI {
 
     pub fn previous_tab(&mut self) {
         self.tabs.previous();
+    }
+
+    pub fn chart_left_bound(&self) -> Instant {
+        self.chart.left_bound()
     }
 }

--- a/src/ui/processes.rs
+++ b/src/ui/processes.rs
@@ -3,7 +3,7 @@ use tui::style::{Color, Modifier, Style};
 use tui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
 use tui::Frame;
 
-use crate::core::process::{Pid, ProcessMetadata};
+use crate::core::process::{Pid, ProcessMetadata, Status};
 use crate::core::view::MetricsOverview;
 use crate::ui::terminal::TuiBackend;
 
@@ -185,7 +185,10 @@ impl ProcessList {
         let str_metrics: Vec<String> = self
             .processes
             .iter()
-            .map(|pm| self.formatted_process_metric(pm, metrics_overview))
+            .map(|pm| match pm.status() {
+                Status::RUNNING => self.formatted_process_metric(pm, metrics_overview),
+                Status::DEAD => self.justify_metric_repr("DEAD".to_string()),
+            })
             .collect();
 
         let items: Vec<ListItem> = str_metrics.iter().map(|pm| ListItem::new(pm.as_str())).collect();


### PR DESCRIPTION
Currently, a dead process immediately disapears from the UI.
With this PR, a dead process is still displayed until its last metric moves out of the scope of the chart.
Dead processes are marked as so in the UI:
* In the lower section of the UI, displaying the selected process' metadata, `(dead)` appears next to the PID
* In the process list section, marked processes have a displayed current value **`DEAD`**

Once the last metric of a dead process is so old that it will not be rendered by the chart, the process disappears from the process list.

The age of processes and metrics are kept in track using the main loop's iteration count. This value is more exact and more easily manipulable/testable than `Instant` instances.