### PR TITLE
Broad refactoring of application

### DIFF
--- a/src/core/collection.rs
+++ b/src/core/collection.rs
@@ -4,10 +4,10 @@ use std::cmp::Ordering;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
-use crate::core::iteration::{Span, Iteration};
+use crate::core::iteration::Span;
 use crate::core::metrics::Metric;
 use crate::core::probe::Probe;
-use crate::core::process::Pid;
+use crate::core::process::{Pid, ProcessMetadata};
 use crate::core::view::{MetricView, MetricsOverview};
 use crate::core::Error;
 
@@ -22,8 +22,7 @@ pub trait MetricCollector {
     ///
     /// # Arguments
     ///  * `pids`: A slice containing the [`Pids`](crate::core::process::Pid) to probe.
-    ///  * `current_iteration`: Indicates the iteration number referencing the metrics collected by this call
-    fn collect(&mut self, pids: &[Pid], current_iteration: Iteration) -> Result<(), Error>;
+    fn collect(&mut self, pids: &[Pid]) -> Result<(), Error>;
 
     /// Probes metrics for the given processes, without storing them.
     ///
@@ -54,9 +53,9 @@ pub trait MetricCollector {
     /// metrics of a given process.
     ///
     /// # Arguments
-    ///  * `pid`: The ID of the process for which to retrieve metrics
+    ///  * `pm`: The process for which to view metrics
     ///  * `span`: The span of iterations covered by the metric view
-    fn view(&self, pid: Pid, span: Span) -> MetricView;
+    fn view(&self, pm: &ProcessMetadata, span: Span) -> MetricView;
 
     /// Builds a [`MetricsOverview`](crate::core::view::MetricsOverview), containing the last metrics
     /// of all running processes.
@@ -90,11 +89,11 @@ impl<M> MetricCollector for ProbeCollector<M>
 where
     M: Metric + Copy + PartialOrd + Default,
 {
-    fn collect(&mut self, pids: &[Pid], current_iteration: Iteration) -> Result<(), Error> {
+    fn collect(&mut self, pids: &[Pid]) -> Result<(), Error> {
         let metrics = self.probe.probe_processes(pids)?;
 
         for (pid, m) in metrics.into_iter() {
-            self.collection.push(pid, m, current_iteration);
+            self.collection.push(pid, m);
         }
 
         Ok(())
@@ -115,8 +114,8 @@ where
         self.probe.name()
     }
 
-    fn view(&self, pid: Pid, span: Span) -> MetricView {
-        self.collection.view(pid, span)
+    fn view(&self, pm: &ProcessMetadata, span: Span) -> MetricView {
+        self.collection.view(pm, span)
     }
 
     fn overview(&self) -> MetricsOverview {
@@ -133,13 +132,14 @@ mod test_probe_collector {
 
     use crate::core::collection::{MetricCollector, ProbeCollector};
     use crate::core::iteration::Span;
-    use crate::core::metrics::PercentMetric;
+    use crate::core::metrics::{Metric, PercentMetric};
     use crate::core::probe::Probe;
-    use crate::core::process::Pid;
+    use crate::core::process::{Pid, ProcessMetadata};
     use crate::core::Error;
 
     struct ProbeFake {
         return_map: Option<HashMap<Pid, f64>>,
+        sequence: Option<Vec<f64>>,
     }
 
     impl Probe<PercentMetric> for ProbeFake {
@@ -150,63 +150,128 @@ mod test_probe_collector {
         fn probe(&mut self, pid: Pid) -> Result<PercentMetric, Error> {
             if let Some(return_map) = self.return_map.as_ref() {
                 Ok(PercentMetric::new(*return_map.get(&pid).unwrap()))
+            } else if let Some(sequence) = self.sequence.as_mut() {
+                Ok(PercentMetric::new(sequence.pop().unwrap()))
             } else {
                 Ok(PercentMetric::new(1.))
             }
         }
     }
 
-    fn create_probe_collector() -> ProbeCollector<PercentMetric> {
-        let probe = ProbeFake { return_map: None };
-        ProbeCollector::new(probe)
-    }
-
-    fn create_probe_collector_with_return_map(return_map: HashMap<Pid, f64>) -> ProbeCollector<PercentMetric> {
+    fn create_collector() -> ProbeCollector<PercentMetric> {
         let probe = ProbeFake {
-            return_map: Some(return_map),
+            return_map: None,
+            sequence: None,
         };
         ProbeCollector::new(probe)
     }
 
-    #[test]
-    fn test_collector_should_be_empty_by_default() {
-        let collector = create_probe_collector();
-        let view = collector.view(0, Span::from_end_and_size(60, 60));
+    fn create_collector_with_map(return_map: HashMap<Pid, f64>) -> ProbeCollector<PercentMetric> {
+        let probe = ProbeFake {
+            return_map: Some(return_map),
+            sequence: None,
+        };
+        ProbeCollector::new(probe)
+    }
+
+    fn create_collector_with_sequence_and_collect(pid: Pid, mut sequence: Vec<f64>) -> ProbeCollector<PercentMetric> {
+        let sequence_len = sequence.len();
+        sequence.reverse();
+
+        let probe = ProbeFake {
+            return_map: None,
+            sequence: Some(sequence),
+        };
+        let mut collector = ProbeCollector::new(probe);
+
+        for _ in 0..sequence_len {
+            collector.collect(&[pid]).unwrap();
+        }
+
+        collector
+    }
+
+    #[fixture]
+    fn process_metadata() -> ProcessMetadata {
+        ProcessMetadata::new(2, 0, "command")
+    }
+
+    #[rstest]
+    fn test_collector_should_be_empty_by_default(process_metadata: ProcessMetadata) {
+        let collector = create_collector();
+        let view = collector.view(&process_metadata, Span::from_end_and_size(60, 60));
 
         assert_eq!(view.as_slice().len(), 0);
     }
 
-    #[test]
-    fn test_collector_should_be_empty_when_only_calibrated() {
-        let mut collector = create_probe_collector();
+    #[rstest]
+    fn test_collector_should_be_empty_when_only_calibrated(process_metadata: ProcessMetadata) {
+        let mut collector = create_collector();
         collector.calibrate(&[1, 2, 3]).unwrap();
 
-        let view = collector.view(0, Span::from_end_and_size(60, 60));
+        let view = collector.view(&process_metadata, Span::from_end_and_size(60, 60));
 
         assert_eq!(view.as_slice().len(), 0);
     }
 
-    #[test]
-    fn test_process_metrics_should_be_empty_when_process_has_not_been_collected() {
-        let mut collector = create_probe_collector();
-        collector.collect(&[1], 1).unwrap();
+    #[rstest]
+    fn test_process_metrics_should_be_empty_when_process_has_not_been_collected(process_metadata: ProcessMetadata) {
+        let mut collector = create_collector();
+        collector.collect(&[1]).unwrap();
 
-        let view = collector.view(2, Span::from_end_and_size(60, 60));
+        let view = collector.view(&process_metadata, Span::from_end_and_size(60, 60));
 
         assert_eq!(view.as_slice().len(), 0);
     }
 
-    #[test]
-    fn test_collector_should_not_be_empty_when_metrics_collected() {
+    #[rstest]
+    fn test_collector_should_not_be_empty_when_metrics_collected(process_metadata: ProcessMetadata) {
         let return_map = hashmap!(1 => 50., 2 => 45.);
-        let mut collector = create_probe_collector_with_return_map(return_map);
-        collector.collect(&[1, 2], 1).unwrap();
+        let mut collector = create_collector_with_map(return_map);
+        collector.collect(&[1, 2]).unwrap();
 
-        let view = collector.view(2, Span::from_end_and_size(60, 60));
+        let view = collector.view(&process_metadata, Span::from_end_and_size(60, 60));
         let extract = view.as_slice();
 
         assert_eq!(extract.len(), 1);
         assert_eq!(extract[0], &PercentMetric::new(45.));
+    }
+
+    #[rstest]
+    fn test_extract_should_return_only_last_metric_if_span_coveres_1_iteration(process_metadata: ProcessMetadata) {
+        let collector = create_collector_with_sequence_and_collect(process_metadata.pid(), vec![0., 1.]);
+        let view = collector.view(&process_metadata, Span::from_end_and_size(1, 1));
+
+        assert_eq!(view.as_slice(), &[view.last_or_default()]);
+    }
+
+    #[rstest]
+    fn test_extract_should_return_two_last_metric_if_span_covers_2_iterations(process_metadata: ProcessMetadata) {
+        let collector = create_collector_with_sequence_and_collect(process_metadata.pid(), vec![0., 1., 2., 3.]);
+        let view = collector.view(&process_metadata, Span::from_end_and_size(3, 2));
+
+        let expected: &[&dyn Metric; 2] = &[&PercentMetric::new(2.), &PercentMetric::new(3.)];
+
+        assert_eq!(view.as_slice(), expected);
+    }
+
+    #[rstest]
+    fn test_should_only_return_existing_items_when_span_greater_than_metric_count(process_metadata: ProcessMetadata) {
+        let collector = create_collector_with_sequence_and_collect(process_metadata.pid(), vec![0., 1., 2., 3.]);
+        let view = collector.view(&process_metadata, Span::from_end_and_size(60, 60));
+        let extract = view.as_slice();
+
+        assert_eq!(extract.len(), 4);
+        assert_eq!(extract[0], &PercentMetric::new(0.));
+        assert_eq!(extract[3], &PercentMetric::new(3.));
+    }
+
+    #[rstest]
+    fn test_max_f64_should_not_return_values_out_of_span(process_metadata: ProcessMetadata) {
+        let collector = create_collector_with_sequence_and_collect(process_metadata.pid(), vec![10., 0., 2.]);
+        let view = collector.view(&process_metadata, Span::from_end_and_size(2, 2));
+
+        assert_eq!(view.max_f64(), 2.);
     }
 
     #[rstest]
@@ -219,8 +284,8 @@ mod test_probe_collector {
         #[case] expected_ord: Ordering,
     ) {
         let return_map = hashmap!(1 => metric_pid1, 2 => metric_pid2);
-        let mut collector = create_probe_collector_with_return_map(return_map);
-        collector.collect(&[1, 2], 1).unwrap();
+        let mut collector = create_collector_with_map(return_map);
+        collector.collect(&[1, 2]).unwrap();
 
         assert_eq!(collector.compare_pids_by_last_metrics(1, 2), expected_ord);
     }
@@ -228,7 +293,7 @@ mod test_probe_collector {
     #[test]
     fn test_collector_should_compare_pid_as_equal_when_not_collected() {
         let return_map = hashmap!(1 => 50., 2 => 45.);
-        let mut collector = create_probe_collector_with_return_map(return_map);
+        let mut collector = create_collector_with_map(return_map);
         collector.calibrate(&[1, 2]).unwrap(); // we calibrate here, we do not collect
 
         assert_eq!(collector.compare_pids_by_last_metrics(1, 2), Ordering::Equal);
@@ -237,8 +302,8 @@ mod test_probe_collector {
     #[test]
     fn test_collector_should_compare_process_metric_to_default_metric_when_other_process_has_not_been_collected() {
         let return_map = hashmap!(1 => 50.);
-        let mut collector = create_probe_collector_with_return_map(return_map);
-        collector.collect(&[1], 1).unwrap();
+        let mut collector = create_collector_with_map(return_map);
+        collector.collect(&[1]).unwrap();
 
         // Pid 1 should be Ordering::Greater than Pid 2 with 50% > default=0%
         assert_eq!(collector.compare_pids_by_last_metrics(1, 2), Ordering::Greater);
@@ -254,7 +319,6 @@ where
     M: Metric + Copy + PartialOrd + Default,
 {
     series: HashMap<Pid, Vec<M>>,
-    last_pushed_iteration: HashMap<Pid, Iteration>,
     default: M,
 }
 
@@ -265,27 +329,17 @@ where
     pub fn new() -> Self {
         Self {
             series: HashMap::new(),
-            last_pushed_iteration: HashMap::new(),
             default: M::default(),
         }
     }
 
-    pub fn push(&mut self, pid: Pid, metric: M, current_iteration: Iteration) {
+    pub fn push(&mut self, pid: Pid, metric: M) {
         let process_series = match self.series.entry(pid) {
             Entry::Occupied(o) => o.into_mut(),
             Entry::Vacant(v) => v.insert(Vec::new()),
         };
 
         process_series.push(metric);
-
-        match self.last_pushed_iteration.entry(pid) {
-            Entry::Occupied(mut o) => {
-                o.insert(current_iteration);
-            }
-            Entry::Vacant(v) => {
-                v.insert(current_iteration);
-            }
-        };
     }
 
     pub fn last_or_default(&self, pid: Pid) -> &M {
@@ -301,11 +355,9 @@ where
             .ok_or(Error::InvalidPID(pid))
     }
 
-    pub fn view(&self, pid: Pid, span: Span) -> MetricView {
-        let metrics = self.extract_metrics_according_to_span(pid, &span);
-        let last_pushed_iteration = self.last_pushed_iteration.get(&pid).cloned().unwrap_or(Iteration::MIN);
-
-        MetricView::new(metrics, &self.default, span, last_pushed_iteration)
+    pub fn view(&self, pm: &ProcessMetadata, span: Span) -> MetricView {
+        let metrics = self.extract_metrics_according_to_span(pm.pid(), &span);
+        MetricView::new(metrics, &self.default, span, pm.running_span().begin())
     }
 
     fn extract_metrics_according_to_span(&self, pid: Pid, span: &Span) -> Vec<&dyn Metric> {
@@ -349,8 +401,8 @@ mod test_metric_collection {
     #[test]
     fn test_should_return_last_metric_when_has_metric() {
         let mut collection = MetricCollection::<PercentMetric>::new();
-        collection.push(1, PercentMetric::new(1.), 1);
-        collection.push(1, PercentMetric::new(2.), 1);
+        collection.push(1, PercentMetric::new(1.));
+        collection.push(1, PercentMetric::new(2.));
 
         assert_eq!(collection.last_or_default(1), &PercentMetric::new(2.));
     }

--- a/src/core/collection.rs
+++ b/src/core/collection.rs
@@ -171,7 +171,7 @@ mod test_probe_collector {
     #[test]
     fn test_collector_should_be_empty_by_default() {
         let collector = create_probe_collector();
-        let view = collector.view(0, Span::default());
+        let view = collector.view(0, Span::from_end_and_size(60, 60));
 
         assert_eq!(view.as_slice().len(), 0);
     }
@@ -181,7 +181,7 @@ mod test_probe_collector {
         let mut collector = create_probe_collector();
         collector.calibrate(&[1, 2, 3]).unwrap();
 
-        let view = collector.view(0, Span::default());
+        let view = collector.view(0, Span::from_end_and_size(60, 60));
 
         assert_eq!(view.as_slice().len(), 0);
     }
@@ -191,7 +191,7 @@ mod test_probe_collector {
         let mut collector = create_probe_collector();
         collector.collect(&[1], 1).unwrap();
 
-        let view = collector.view(2, Span::default());
+        let view = collector.view(2, Span::from_end_and_size(60, 60));
 
         assert_eq!(view.as_slice().len(), 0);
     }
@@ -202,7 +202,7 @@ mod test_probe_collector {
         let mut collector = create_probe_collector_with_return_map(return_map);
         collector.collect(&[1, 2], 1).unwrap();
 
-        let view = collector.view(2, Span::default());
+        let view = collector.view(2, Span::from_end_and_size(60, 60));
         let extract = view.as_slice();
 
         assert_eq!(extract.len(), 1);

--- a/src/core/collection.rs
+++ b/src/core/collection.rs
@@ -249,7 +249,7 @@ mod test_probe_collector {
     }
 
     #[rstest]
-    fn test_extract_should_return_only_last_metric_if_span_coveres_1_iteration(process_metadata: ProcessMetadata) {
+    fn test_extract_should_return_only_last_metric_if_span_covers_1_iteration(process_metadata: ProcessMetadata) {
         let collector = create_collector_with_sequence_and_collect(process_metadata.pid(), vec![0., 1.]);
         let view = collector.view(&process_metadata, Span::new(1, 1));
 

--- a/src/core/iteration.rs
+++ b/src/core/iteration.rs
@@ -79,21 +79,24 @@ impl Span {
         Span { begin: 0, end: 0, size }
     }
 
-    /// Updates the end of the span and updates the `begin` attribute using the `size` attribute
+    /// Updates the end of the span and updates the `begin` attribute using the `size` attribute.
+    /// After this operation, the size of the span will remain the same.
+    ///
     /// # Arguments
     /// * `end`: The last iteration covered by the span
-    pub fn set_end_and_update_begin(&mut self, end: Iteration) {
+    pub fn set_end_and_shift(&mut self, end: Iteration) {
         self.end = end;
         self.begin = end.checked_sub(self.size).map(|v| v + 1).unwrap_or(Iteration::MIN);
     }
 
     /// Updates the end of the span and updates the `size` attribute using the `begin` attribute
+    /// After this operation, the `begin` iteration of the span will remain the same.
     ///
     /// This method panics if `end` is less than `begin`.
     ///
     /// # Arguments
     /// * `end`: The last iteration covered by the span
-    pub fn set_end_and_update_size(&mut self, end: Iteration) {
+    pub fn set_end_and_resize(&mut self, end: Iteration) {
         self.end = end;
         self.size = self.end.checked_sub(self.begin).unwrap() + 1;
     }
@@ -155,7 +158,7 @@ mod test_span {
     #[test]
     fn test_should_update_begin_when_setting_end_and_updating_begin() {
         let mut span = Span::from_size(60);
-        span.set_end_and_update_begin(180);
+        span.set_end_and_shift(180);
 
         assert_eq!(span.begin(), 121);
     }
@@ -163,7 +166,7 @@ mod test_span {
     #[test]
     fn test_should_prevent_underflow_when_setting_end_and_updating_begin() {
         let mut span = Span::from_size(60);
-        span.set_end_and_update_begin(30);
+        span.set_end_and_shift(30);
 
         assert_eq!(span.begin(), 0);
     }
@@ -171,7 +174,7 @@ mod test_span {
     #[test]
     fn test_should_update_end_when_setting_end_and_updating_begin() {
         let mut span = Span::from_size(60);
-        span.set_end_and_update_begin(180);
+        span.set_end_and_shift(180);
 
         assert_eq!(span.end(), 180);
     }
@@ -179,7 +182,7 @@ mod test_span {
     #[test]
     fn test_should_not_update_size_when_setting_end_and_updating_begin() {
         let mut span = Span::from_size(60);
-        span.set_end_and_update_begin(180);
+        span.set_end_and_shift(180);
 
         assert_eq!(span.size(), 60);
     }
@@ -187,7 +190,7 @@ mod test_span {
     #[test]
     fn test_should_update_size_when_setting_end_and_updating_size() {
         let mut span = Span::from_begin(121);
-        span.set_end_and_update_size(240);
+        span.set_end_and_resize(240);
 
         assert_eq!(span.size(), 120);
     }
@@ -195,7 +198,7 @@ mod test_span {
     #[test]
     fn test_should_update_end_when_setting_end_and_updating_size() {
         let mut span = Span::from_begin(121);
-        span.set_end_and_update_size(180);
+        span.set_end_and_resize(180);
 
         assert_eq!(span.end(), 180);
     }
@@ -203,7 +206,7 @@ mod test_span {
     #[test]
     fn test_should_not_update_begin_when_setting_end_and_updating_size() {
         let mut span = Span::from_begin(121);
-        span.set_end_and_update_size(180);
+        span.set_end_and_resize(180);
 
         assert_eq!(span.begin(), 121);
     }

--- a/src/core/iteration.rs
+++ b/src/core/iteration.rs
@@ -62,10 +62,7 @@ impl Span {
     #[cfg(test)]
     pub fn from_end_and_size(end: Iteration, size: Iteration) -> Self {
         Span {
-            begin: end
-                .checked_sub(size)
-                .and_then(|v| Some(v + 1))
-                .unwrap_or(Iteration::MIN),
+            begin: end.checked_sub(size).map(|v| v + 1).unwrap_or(Iteration::MIN),
             end,
             size,
         }
@@ -87,10 +84,7 @@ impl Span {
     /// * `end`: The last iteration covered by the span
     pub fn set_end_and_update_begin(&mut self, end: Iteration) {
         self.end = end;
-        self.begin = end
-            .checked_sub(self.size)
-            .and_then(|v| Some(v + 1))
-            .unwrap_or(Iteration::MIN);
+        self.begin = end.checked_sub(self.size).map(|v| v + 1).unwrap_or(Iteration::MIN);
     }
 
     /// Updates the end of the span and updates the `size` attribute using the `begin` attribute

--- a/src/core/iteration.rs
+++ b/src/core/iteration.rs
@@ -1,7 +1,10 @@
-/// On every iteration of the application's main loop, all processes will be probed for their metrics
-/// An Iteration value refers to one of these iterations
+//! Time measure and associated tools
+
+/// Represents an iteration of the program's main loop
 pub type Iteration = usize;
 
+
+/// Keeps track of the current iteration of the program
 pub struct IterationTracker {
     counter: usize,
 }
@@ -51,6 +54,9 @@ mod test_iteration {
 }
 
 /// Represents a temporal region, expressed using iterations
+///
+/// A `Span` has a `begin`, an `end` and a `size`.
+/// The `begin` and `end` are inclusive.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct Span {
     begin: Iteration,
@@ -68,6 +74,11 @@ impl Span {
         }
     }
 
+    /// Creates a `Span` starting at the given `Iteration`
+    /// The `Span` will have a size of 1. This means that it ends at the same `Iteration` than `begin`.
+    ///
+    /// # Arguments
+    /// * `begin`: The left-bound iteration of the span
     pub fn from_begin(begin: Iteration) -> Self {
         Span {
             begin,
@@ -76,8 +87,18 @@ impl Span {
         }
     }
 
+    /// Creates a `Span` with the given size
+    /// The `Span` ends at the `Iteration` 0.
+    /// To update the end of the span, see [`set_end_and_shift`](#method.set_end_and_shift)
+    ///
+    /// # Arguments
+    /// * `size`: The size of the `Span`
     pub fn from_size(size: Iteration) -> Self {
-        Span { begin: 0, end: size - 1, size }
+        Span {
+            begin: 0,
+            end: 0,
+            size,
+        }
     }
 
     /// Updates the end of the span and updates the `begin` attribute using the `size` attribute.
@@ -102,7 +123,7 @@ impl Span {
         self.size = self.end.checked_sub(self.begin).unwrap() + 1;
     }
 
-    /// Returns the first iteration covered by the span
+    /// Returns the first iteration covered by the span.
     /// This value can never be greater than `self.end()`
     pub fn begin(&self) -> Iteration {
         self.begin
@@ -152,7 +173,7 @@ mod test_span {
         let span = Span::from_size(60);
 
         assert_eq!(span.begin(), 0);
-        assert_eq!(span.end(), 59);
+        assert_eq!(span.end(), 0);
         assert_eq!(span.size(), 60);
     }
 

--- a/src/core/iteration.rs
+++ b/src/core/iteration.rs
@@ -2,23 +2,22 @@
 /// An Iteration value refers to one of these iterations
 pub type Iteration = usize;
 
-// TODO It would be simpler if this were a singleton, no need to pass an `Iteration` value everywhere
-pub struct IterTracker {
+pub struct IterationTracker {
     counter: usize,
 }
 
-impl Default for IterTracker {
+impl Default for IterationTracker {
     fn default() -> Self {
-        IterTracker { counter: 0 }
+        IterationTracker { counter: 0 }
     }
 }
 
-impl IterTracker {
+impl IterationTracker {
     pub fn tick(&mut self) {
         self.counter += 1
     }
 
-    pub fn iteration(&self) -> usize {
+    pub fn current(&self) -> usize {
         self.counter
     }
 }
@@ -27,27 +26,27 @@ impl IterTracker {
 mod test_iteration {
     use rstest::*;
 
-    use crate::core::iteration::IterTracker;
+    use crate::core::iteration::IterationTracker;
 
     #[fixture]
-    fn iteration_tracker() -> IterTracker {
-        IterTracker::default()
+    fn iteration_tracker() -> IterationTracker {
+        IterationTracker::default()
     }
 
     #[rstest]
-    fn test_iteration_should_be_0_by_default(iteration_tracker: IterTracker) {
-        assert_eq!(iteration_tracker.iteration(), 0);
+    fn test_iteration_should_be_0_by_default(iteration_tracker: IterationTracker) {
+        assert_eq!(iteration_tracker.current(), 0);
     }
 
     #[rstest]
     #[case(1)]
     #[case(5)]
-    fn test_iteration_should_increase_on_tick(mut iteration_tracker: IterTracker, #[case] tick_count: usize) {
+    fn test_iteration_should_increase_on_tick(mut iteration_tracker: IterationTracker, #[case] tick_count: usize) {
         for _ in 0..tick_count {
             iteration_tracker.tick();
         }
 
-        assert_eq!(iteration_tracker.iteration(), tick_count);
+        assert_eq!(iteration_tracker.current(), tick_count);
     }
 }
 

--- a/src/core/iteration.rs
+++ b/src/core/iteration.rs
@@ -60,13 +60,14 @@ pub struct Span {
 
 impl Span {
     #[cfg(test)]
-    pub fn from_end_and_size(end: Iteration, size: Iteration) -> Self {
+    pub fn new(begin: Iteration, end: Iteration) -> Self {
         Span {
-            begin: end.checked_sub(size).map(|v| v + 1).unwrap_or(Iteration::MIN),
+            begin,
             end,
-            size,
+            size: end - begin + 1,
         }
     }
+
     pub fn from_begin(begin: Iteration) -> Self {
         Span {
             begin,
@@ -76,7 +77,7 @@ impl Span {
     }
 
     pub fn from_size(size: Iteration) -> Self {
-        Span { begin: 0, end: 0, size }
+        Span { begin: 0, end: size - 1, size }
     }
 
     /// Updates the end of the span and updates the `begin` attribute using the `size` attribute.
@@ -151,7 +152,7 @@ mod test_span {
         let span = Span::from_size(60);
 
         assert_eq!(span.begin(), 0);
-        assert_eq!(span.end(), 0);
+        assert_eq!(span.end(), 59);
         assert_eq!(span.size(), 60);
     }
 
@@ -213,12 +214,12 @@ mod test_span {
 
     #[rstest]
     #[case(50, 250)]
-    #[case(50, 101)]
+    #[case(50, 100)]
     #[case(120, 170)]
-    #[case(200, 250)]
+    #[case(199, 250)]
     fn test_should_return_true_if_spans_intersect(#[case] begin_other: Iteration, #[case] end_other: Iteration) {
-        let span = Span::from_end_and_size(200, 100);
-        let other_span = Span::from_end_and_size(end_other, end_other - begin_other + 1);
+        let span = Span::new(100, 199);
+        let other_span = Span::new(begin_other, end_other);
 
         assert!(span.intersects(&other_span));
     }
@@ -230,8 +231,8 @@ mod test_span {
         #[case] begin_other: Iteration,
         #[case] end_other: Iteration,
     ) {
-        let span = Span::from_end_and_size(200, 100);
-        let other_span = Span::from_end_and_size(end_other, end_other - begin_other + 1);
+        let span = Span::new(100, 199);
+        let other_span = Span::new(begin_other, end_other);
 
         assert!(!span.intersects(&other_span));
     }

--- a/src/core/iteration.rs
+++ b/src/core/iteration.rs
@@ -50,41 +50,65 @@ mod test_iteration {
     }
 }
 
+/// Represents a temporal region, expressed using iterations
 #[derive(Copy, Clone)]
-pub struct IterSpan {
-    span: usize,
+pub struct Span {
+    size: Iteration,
+    end: Iteration,
 }
 
-impl Default for IterSpan {
+impl Default for Span {
     fn default() -> Self {
-        IterSpan {
-            span: 60, // Default hard-coded value, at 1 iteration/s, is a span of 1 minute
+        const DEFAULT_SPAN_WIDTH: Iteration = 60;
+        Span {
+            end: 0,
+            size: DEFAULT_SPAN_WIDTH,
         }
     }
 }
 
-impl IterSpan {
+impl Span {
     #[cfg(test)]
-    pub fn new(span: usize) -> Self {
-        IterSpan { span }
+    pub fn new(span: Iteration, end: Iteration) -> Self {
+        Span { size: span, end }
     }
 
-    pub fn begin(&self, current_iteration: Iteration) -> Iteration {
-        current_iteration.checked_sub(self.span).unwrap_or(Iteration::MIN)
+    pub fn set_end(&mut self, iteration: Iteration) {
+        self.end = iteration;
     }
 
-    pub fn span(&self) -> usize {
-        self.span
+    pub fn size(&self) -> Iteration {
+        self.size
     }
+
+    pub fn begin(&self) -> Iteration {
+        self.end.checked_sub(self.size).unwrap_or(Iteration::MIN)
+    }
+
+    pub fn end(&self) -> Iteration {
+        self.end
+    }
+
+    // TODO implement intersect(span) and contains(iteration) if needed
 }
 
 #[cfg(test)]
-mod test_iter_span {
-    use crate::core::iteration::IterSpan;
+mod test_iteration_span {
+    use crate::core::iteration::Span;
 
     #[test]
-    fn test_should_substract_60_iteration_to_get_begin() {
-        let span = IterSpan::default();
-        assert_eq!(span.begin(120), 60);
+    fn test_should_update_begin_when_setting_end() {
+        let mut span = Span::default();
+        span.set_end(180);
+
+        assert_eq!(span.begin(), 180 - span.size());
+    }
+
+    #[test]
+    fn test_should_update_end_when_setting_end() {
+        let mut span = Span::default();
+        span.set_end(123);
+
+        assert_eq!(span.end(), 123);
     }
 }

--- a/src/core/iteration.rs
+++ b/src/core/iteration.rs
@@ -3,7 +3,6 @@
 /// Represents an iteration of the program's main loop
 pub type Iteration = usize;
 
-
 /// Keeps track of the current iteration of the program
 pub struct IterationTracker {
     counter: usize,
@@ -94,11 +93,7 @@ impl Span {
     /// # Arguments
     /// * `size`: The size of the `Span`
     pub fn from_size(size: Iteration) -> Self {
-        Span {
-            begin: 0,
-            end: 0,
-            size,
-        }
+        Span { begin: 0, end: 0, size }
     }
 
     /// Updates the end of the span and updates the `begin` attribute using the `size` attribute.
@@ -127,6 +122,13 @@ impl Span {
     /// This value can never be greater than `self.end()`
     pub fn begin(&self) -> Iteration {
         self.begin
+    }
+
+    /// Returns the first iteration covered by the span, even if this iteration is negative.
+    ///
+    /// It is possible for a `Span` to start at a negative iteration, if `size` is greater than `end`.
+    pub fn signed_begin(&self) -> i128 {
+        self.end as i128 - self.size as i128 + 1
     }
 
     /// Returns the last iteration covered by the span
@@ -256,5 +258,21 @@ mod test_span {
         let other_span = Span::new(begin_other, end_other);
 
         assert!(!span.intersects(&other_span));
+    }
+
+    #[test]
+    fn test_should_return_negative_begin_when_size_greater_than_end() {
+        let mut span = Span::from_size(60);
+        span.set_end_and_shift(30);
+
+        assert_eq!(span.signed_begin(), -29);
+    }
+
+    #[test]
+    fn test_should_return_positive_begin_when_size_less_than_end() {
+        let mut span = Span::from_size(60);
+        span.set_end_and_shift(120);
+
+        assert_eq!(span.signed_begin(), 61);
     }
 }

--- a/src/core/iteration.rs
+++ b/src/core/iteration.rs
@@ -55,7 +55,7 @@ mod test_iteration {
 pub struct Span {
     begin: Iteration,
     end: Iteration,
-    size: Iteration, // iteration is required as an attribute, for the cases where size > end (as begin cannot be < 0)
+    size: Iteration, // size is required as an attribute, to represent spans including the iteration 0 (e.g. [-59;0])
 }
 
 impl Span {

--- a/src/core/process.rs
+++ b/src/core/process.rs
@@ -371,7 +371,7 @@ mod test_process_collector {
     fn test_running_processes_should_only_return_running_processes() {
         let pids_sequence = vec![
             vec![1, 2, 3], // Processes 1, 2 and 3 are running
-            vec![1],    // Only process 1 is still running
+            vec![1],       // Only process 1 is still running
         ];
         let collector = build_collector_with_sequence_and_collect(pids_sequence);
 
@@ -384,7 +384,7 @@ mod test_process_collector {
     fn test_running_pids_should_only_return_running_processes() {
         let pids_sequence = vec![
             vec![1, 2, 3], // Processes 1, 2 and 3 are running
-            vec![1],    // Only process 1 is still running
+            vec![1],       // Only process 1 is still running
         ];
         let collector = build_collector_with_sequence_and_collect(pids_sequence);
 

--- a/src/core/process.rs
+++ b/src/core/process.rs
@@ -397,11 +397,11 @@ mod test_process_collector {
 
         collector.collect_processes(0).unwrap();
         let running_process = &collector.running_processes()[0];
-        assert_eq!(running_process.running_span(), &Span::from_end_and_size(0, 1));
+        assert_eq!(running_process.running_span(), &Span::new(0, 0));
 
         collector.collect_processes(1).unwrap();
         let running_process = &collector.running_processes()[0];
-        assert_eq!(running_process.running_span(), &Span::from_end_and_size(1, 2));
+        assert_eq!(running_process.running_span(), &Span::new(0, 1));
     }
 }
 

--- a/src/core/process.rs
+++ b/src/core/process.rs
@@ -86,7 +86,7 @@ impl ProcessMetadata {
     /// # Arguments
     /// * `current_iteration`: The iteration at which the process is still running
     fn mark_alive_at_iteration(&mut self, current_iteration: Iteration) {
-        self.running_span.set_end_and_update_size(current_iteration);
+        self.running_span.set_end_and_resize(current_iteration);
     }
 }
 

--- a/src/core/view.rs
+++ b/src/core/view.rs
@@ -134,7 +134,7 @@ mod test_metric_view {
     #[test]
     fn test_last_or_default_should_be_latest_metric_when_exists() {
         let collection = produce_metrics_collection(1, vec![0., 1.]);
-        let view = collection.view(0, Span::default());
+        let view = collection.view(0, Span::from_end_and_size(60, 60));
 
         assert_eq!(view.last_or_default(), &PercentMetric::new(1.));
     }
@@ -142,7 +142,7 @@ mod test_metric_view {
     #[test]
     fn test_last_or_default_should_be_default_when_pid_unknown() {
         let collection = MetricCollection::<PercentMetric>::new();
-        let view = collection.view(0, Span::default());
+        let view = collection.view(0, Span::from_end_and_size(60, 60));
 
         assert_eq!(view.last_or_default(), &PercentMetric::default());
     }
@@ -150,7 +150,7 @@ mod test_metric_view {
     #[test]
     fn test_unit_should_be_metric_unit() {
         let collection = MetricCollection::<PercentMetric>::new();
-        let view = collection.view(0, Span::default());
+        let view = collection.view(0, Span::from_end_and_size(60, 60));
 
         assert_eq!(view.unit(), PercentMetric::default().unit());
     }
@@ -158,7 +158,7 @@ mod test_metric_view {
     #[test]
     fn test_extract_should_extract_nothing_if_collection_is_empty() {
         let collection = MetricCollection::<PercentMetric>::new();
-        let view = collection.view(0, Span::default());
+        let view = collection.view(0, Span::from_end_and_size(60, 60));
 
         assert_eq!(view.as_slice(), &[]);
     }
@@ -166,7 +166,7 @@ mod test_metric_view {
     #[test]
     fn test_extract_should_return_only_last_metric_if_span_coveres_1_iteration() {
         let collection = produce_metrics_collection(1, vec![0., 1.]);
-        let view = collection.view(0, Span::new(1, 1));
+        let view = collection.view(0, Span::from_end_and_size(1, 1));
 
         assert_eq!(view.as_slice(), &[view.last_or_default()]);
     }
@@ -174,7 +174,7 @@ mod test_metric_view {
     #[test]
     fn test_extract_should_return_two_last_metric_if_span_covers_2_iterations() {
         let collection = produce_metrics_collection(1, vec![0., 1., 2., 3.]);
-        let view = collection.view(0, Span::new(2, 3));
+        let view = collection.view(0, Span::from_end_and_size(3, 2));
 
         let expected: &[&dyn Metric; 2] = &[&PercentMetric::new(2.), &PercentMetric::new(3.)];
 
@@ -184,7 +184,7 @@ mod test_metric_view {
     #[test]
     fn test_should_only_return_existing_items_when_span_greater_than_metric_count() {
         let collection = produce_metrics_collection(1, vec![0., 1., 2.]);
-        let view = collection.view(0, Span::new(20, 2));
+        let view = collection.view(0, Span::from_end_and_size(60, 60));
         let extract = view.as_slice();
 
         assert_eq!(extract.len(), 3);
@@ -195,7 +195,7 @@ mod test_metric_view {
     #[test]
     fn test_max_f64_should_return_max_value() {
         let collection = produce_metrics_collection(1, vec![10., 0., 2.]);
-        let view = collection.view(0, Span::default());
+        let view = collection.view(0, Span::from_end_and_size(60, 60));
 
         assert_eq!(view.max_f64(), 10.);
     }
@@ -203,7 +203,7 @@ mod test_metric_view {
     #[test]
     fn test_max_f64_should_not_return_values_out_of_span() {
         let collection = produce_metrics_collection(1, vec![10., 0., 2.]);
-        let view = collection.view(0, Span::new(2, 2));
+        let view = collection.view(0, Span::from_end_and_size(2, 2));
 
         assert_eq!(view.max_f64(), 2.);
     }
@@ -211,7 +211,7 @@ mod test_metric_view {
     #[test]
     fn test_max_f64_should_return_0_when_empty() {
         let collection = MetricCollection::<PercentMetric>::new();
-        let view = collection.view(0, Span::default());
+        let view = collection.view(0, Span::from_end_and_size(60, 60));
 
         assert_eq!(view.max_f64(), 0.);
     }
@@ -219,7 +219,7 @@ mod test_metric_view {
     #[test]
     fn test_max_repr_should_return_repr_of_max_value() {
         let collection = produce_metrics_collection(1, vec![0., 10., 2.]);
-        let view = collection.view(0, Span::default());
+        let view = collection.view(0, Span::from_end_and_size(60, 60));
 
         assert_eq!(view.max_concise_repr(), "10.0".to_string());
     }
@@ -228,7 +228,7 @@ mod test_metric_view {
     fn test_should_return_0_as_default_last_iteration() {
         let collection = MetricCollection::<PercentMetric>::new();
 
-        let view = collection.view(1, Span::default());
+        let view = collection.view(1, Span::from_end_and_size(60, 60));
         assert_eq!(view.last_iteration(), 0);
     }
 
@@ -238,7 +238,7 @@ mod test_metric_view {
         collection.push(1, PercentMetric::new(10.), 1);
         collection.push(1, PercentMetric::new(10.), 2);
 
-        let view = collection.view(1, Span::default());
+        let view = collection.view(1, Span::from_end_and_size(60, 60));
         assert_eq!(view.last_iteration(), 2);
     }
 
@@ -248,8 +248,8 @@ mod test_metric_view {
         collection.push(1, PercentMetric::new(10.), 1);
         collection.push(1, PercentMetric::new(10.), 2);
 
-        let view = collection.view(1, Span::new(123, 2));
-        assert_eq!(view.span().size(), 123);
+        let view = collection.view(1, Span::from_end_and_size(123, 456));
+        assert_eq!(view.span(), &Span::from_end_and_size(123, 456));
     }
 }
 

--- a/src/core/view.rs
+++ b/src/core/view.rs
@@ -148,7 +148,7 @@ mod test_metric_view {
     #[rstest]
     fn test_last_or_default_should_be_latest_metric_when_metrics_exists(metrics: Vec<PercentMetric>) {
         let default = PercentMetric::default();
-        let view = MetricView::new(metrics_to_dyn(&metrics), &default, Span::from_end_and_size(10, 10), 1);
+        let view = MetricView::new(metrics_to_dyn(&metrics), &default, Span::new(10, 10), 1);
 
         assert_eq!(view.last_or_default(), metrics.last().unwrap());
     }
@@ -156,7 +156,7 @@ mod test_metric_view {
     #[test]
     fn test_last_or_default_should_be_default_when_pid_unknown() {
         let default = PercentMetric::default();
-        let view = MetricView::new(vec![], &default, Span::from_end_and_size(10, 10), 1);
+        let view = MetricView::new(vec![], &default, Span::new(1, 10), 1);
 
         assert_eq!(view.last_or_default(), &default);
     }
@@ -164,7 +164,7 @@ mod test_metric_view {
     #[rstest]
     fn test_unit_should_be_metric_unit() {
         let default = PercentMetric::default();
-        let view = MetricView::new(vec![], &default, Span::from_end_and_size(10, 10), 1);
+        let view = MetricView::new(vec![], &default, Span::new(1, 10), 1);
 
         assert_eq!(view.unit(), default.unit());
     }
@@ -172,7 +172,7 @@ mod test_metric_view {
     #[rstest]
     fn test_max_f64_should_return_max_value(metrics: Vec<PercentMetric>) {
         let default = PercentMetric::default();
-        let view = MetricView::new(metrics_to_dyn(&metrics), &default, Span::from_end_and_size(10, 10), 1);
+        let view = MetricView::new(metrics_to_dyn(&metrics), &default, Span::new(1, 10), 1);
 
         assert_eq!(view.max_f64(), 20.);
     }
@@ -180,7 +180,7 @@ mod test_metric_view {
     #[test]
     fn test_max_f64_should_return_default_f64_when_empty() {
         let default = PercentMetric::default();
-        let view = MetricView::new(vec![], &default, Span::from_end_and_size(10, 10), 1);
+        let view = MetricView::new(vec![], &default, Span::new(1, 10), 1);
 
         assert_eq!(view.max_f64(), default.as_f64(0).unwrap());
     }
@@ -188,7 +188,7 @@ mod test_metric_view {
     #[rstest]
     fn test_max_repr_should_return_repr_of_max_value(metrics: Vec<PercentMetric>) {
         let default = PercentMetric::default();
-        let view = MetricView::new(metrics_to_dyn(&metrics), &default, Span::from_end_and_size(10, 10), 1);
+        let view = MetricView::new(metrics_to_dyn(&metrics), &default, Span::new(1, 10), 1);
 
         assert_eq!(view.max_concise_repr(), "20.0".to_string());
     }
@@ -196,7 +196,7 @@ mod test_metric_view {
     #[test]
     fn test_should_return_first_iteration() {
         let default = PercentMetric::default();
-        let view = MetricView::new(vec![], &default, Span::from_end_and_size(10, 10), 1);
+        let view = MetricView::new(vec![], &default, Span::new(1, 10), 1);
 
         assert_eq!(view.first_iteration(), 1);
     }
@@ -204,7 +204,7 @@ mod test_metric_view {
     #[test]
     fn test_should_return_span_begin_as_first_iteration_if_greater_than_first_iteration() {
         let default = PercentMetric::default();
-        let view = MetricView::new(vec![], &default, Span::from_end_and_size(100, 10), 1);
+        let view = MetricView::new(vec![], &default, Span::new(91, 100), 1);
 
         assert_eq!(view.first_iteration(), 91);
     }
@@ -212,9 +212,9 @@ mod test_metric_view {
     #[test]
     fn test_should_return_correct_span() {
         let default = PercentMetric::default();
-        let view = MetricView::new(vec![], &default, Span::from_end_and_size(10, 10), 1);
+        let view = MetricView::new(vec![], &default, Span::new(1, 10), 1);
 
-        assert_eq!(view.span(), &Span::from_end_and_size(10, 10));
+        assert_eq!(view.span(), &Span::new(1, 10));
     }
 }
 

--- a/src/procfs/process.rs
+++ b/src/procfs/process.rs
@@ -9,6 +9,7 @@ use thiserror::Error;
 
 use crate::core::process::{Pid, ProcessMetadata, ProcessScanner};
 use crate::core::Error as CoreError;
+use crate::core::iteration::Iteration;
 
 /// Errors internal to the process module
 #[derive(Error, Debug)]
@@ -84,7 +85,7 @@ impl ProcessScanner for ProcfsScanner {
     ///
     /// # Arguments
     ///  * `pid`: The identifier of the process for which to retrieve metadata
-    fn fetch_metadata(&self, pid: Pid) -> std::result::Result<ProcessMetadata, CoreError> {
+    fn fetch_metadata(&self, pid: Pid, spawn_iteration: Iteration) -> std::result::Result<ProcessMetadata, CoreError> {
         let mut command = String::new();
         let comm_file_path = self.proc_dir.join(pid.to_string()).join("comm");
 
@@ -98,7 +99,7 @@ impl ProcessScanner for ProcfsScanner {
             command.pop();
         }
 
-        Ok(ProcessMetadata::new(pid, command))
+        Ok(ProcessMetadata::new(pid, spawn_iteration, command))
     }
 }
 
@@ -237,10 +238,10 @@ mod test_pid_scanner {
         };
 
         let process_metadata = proc_scanner
-            .fetch_metadata(123)
+            .fetch_metadata(123, 1)
             .expect("Could not get processes metadata");
 
-        assert_eq!(process_metadata, ProcessMetadata::new(123, "test_cmd".to_string()));
+        assert_eq!(process_metadata, ProcessMetadata::new(123, 1, "test_cmd".to_string()));
     }
 
     #[test]
@@ -259,10 +260,10 @@ mod test_pid_scanner {
         };
 
         let process_metadata = proc_scanner
-            .fetch_metadata(123)
+            .fetch_metadata(123, 0)
             .expect("Could not get processes metadata");
 
-        assert_eq!(process_metadata, ProcessMetadata::new(123, "test_cmd".to_string()));
+        assert_eq!(process_metadata, ProcessMetadata::new(123, 0, "test_cmd".to_string()));
     }
 
     #[test]
@@ -273,7 +274,7 @@ mod test_pid_scanner {
             proc_dir: test_proc_dir.path().to_path_buf(),
         };
 
-        let process_metadata_ret = proc_scanner.fetch_metadata(123);
+        let process_metadata_ret = proc_scanner.fetch_metadata(123, 0);
 
         assert!(matches!(process_metadata_ret, Err(CoreError::ScanProcessesError(_))));
     }

--- a/src/procfs/process.rs
+++ b/src/procfs/process.rs
@@ -7,9 +7,9 @@ use std::path::PathBuf;
 
 use thiserror::Error;
 
+use crate::core::iteration::Iteration;
 use crate::core::process::{Pid, ProcessMetadata, ProcessScanner};
 use crate::core::Error as CoreError;
-use crate::core::iteration::Iteration;
 
 /// Errors internal to the process module
 #[derive(Error, Debug)]

--- a/src/spv.rs
+++ b/src/spv.rs
@@ -91,11 +91,9 @@ impl SpvApplication {
         let running_pids = Self::extract_processes_pids(&self.process_view.running_processes());
 
         for collector in self.collectors.values_mut() {
-            collector
-                .collect(&running_pids, self.iteration_tracker.current())
-                .unwrap_or_else(|e| {
-                    warn!("Error reading from collector {}: {}", collector.name(), e.to_string());
-                });
+            collector.collect(&running_pids).unwrap_or_else(|e| {
+                warn!("Error reading from collector {}: {}", collector.name(), e.to_string());
+            });
         }
 
         let mut exposed_processes = self.represented_processes();
@@ -142,8 +140,10 @@ impl SpvApplication {
 
         let overview = current_collector.overview();
 
-        let selected_pid = self.ui.current_process().map(|pm| pm.pid()).unwrap_or(0);
-        let metrics_view = current_collector.view(selected_pid, self.represented_span);
+        let metrics_view = self
+            .ui
+            .current_process()
+            .map(|pm| current_collector.view(pm, self.represented_span));
 
         self.ui.render(&overview, &metrics_view).map_err(Error::UiError)
     }

--- a/src/spv.rs
+++ b/src/spv.rs
@@ -85,7 +85,7 @@ impl SpvApplication {
     fn collect_metrics(&mut self) -> Result<(), Error> {
         self.iteration_tracker.tick();
         self.represented_span
-            .set_end_and_update_begin(self.iteration_tracker.current());
+            .set_end_and_shift(self.iteration_tracker.current());
 
         self.scan_processes()?;
         let running_pids = self.process_view.running_pids();
@@ -104,7 +104,7 @@ impl SpvApplication {
         Ok(())
     }
 
-    fn collect_running_processes(&mut self) -> Result<(), Error> {
+    fn scan_processes(&mut self) -> Result<(), Error> {
         self.process_view
             .collect_processes(self.iteration_tracker.current())
             .map_err(Error::CoreError)?;

--- a/src/ui/chart.rs
+++ b/src/ui/chart.rs
@@ -36,8 +36,10 @@ impl MetricsChart {
         Axis::default()
             .style(Style::default().fg(Color::White))
             .bounds([
-                metrics_view.current_iteration() as f64 - metrics_view.span() as f64,
-                metrics_view.current_iteration() as f64,
+                // We do not use span.begin() here, as it has a min value of 0. On application startup, the bounds
+                // would be squashed between 0 and span.end() until span.end() would be greater than span.size()
+                metrics_view.span().end() as f64 - metrics_view.span().size() as f64,
+                metrics_view.span().end() as f64,
             ])
             .labels(labels)
     }

--- a/src/ui/chart.rs
+++ b/src/ui/chart.rs
@@ -16,12 +16,12 @@ impl Default for MetricsChart {
 
 impl MetricsChart {
     pub fn render(&self, frame: &mut FrameRegion, metrics_view: &MetricView) {
-        let data_frame = DataFrame::new(metrics_view);
+        let raw_data = build_raw_vecs(metrics_view);
 
-        let chart = Chart::new(data_frame.datasets())
+        let chart = Chart::new(build_datasets(&raw_data, metrics_view))
             .block(Block::default().borders(Borders::ALL))
             .x_axis(self.define_x_axis(metrics_view))
-            .y_axis(self.define_y_axis(&data_frame, metrics_view.max_concise_repr(), metrics_view.unit()));
+            .y_axis(self.define_y_axis(metrics_view, metrics_view.max_concise_repr(), metrics_view.unit()));
 
         frame.render_widget(chart);
     }
@@ -44,9 +44,9 @@ impl MetricsChart {
             .labels(labels)
     }
 
-    fn define_y_axis(&self, data_frame: &DataFrame, upper_bound_repr: String, unit: &'static str) -> Axis {
+    fn define_y_axis(&self, metrics_view: &MetricView, upper_bound_repr: String, unit: &'static str) -> Axis {
         const MINIMUM_UPPER_BOUND: f64 = 10.;
-        let upper_bound = (1.1 * data_frame.max_value()).max(MINIMUM_UPPER_BOUND);
+        let upper_bound = (1.1 * metrics_view.max_f64()).max(MINIMUM_UPPER_BOUND);
 
         Axis::default()
             .title(unit)
@@ -60,78 +60,72 @@ impl MetricsChart {
     }
 }
 
-// TODO refactor - DataFrame does not need to be an object. Replace it by functions / and test them
-/// Performs all required operations to get raw "drawable" data from `&[&Metric]`
-struct DataFrame<'a> {
-    metrics_view: &'a MetricView<'a>,
-    // data has to be persisted as an attr, to be able to return a Dataset which references data
-    // from this vec
-    data: Vec<Vec<(f64, f64)>>,
+fn build_datasets<'a>(raw_data: &'a Vec<Vec<(f64, f64)>>, metrics_view: &MetricView) -> Vec<Dataset<'a>> {
+    const COLORS: [Color; 2] = [Color::Blue, Color::Green];
+
+    raw_data
+        .iter()
+        .enumerate()
+        .map(|(index, data)| {
+            let name = metrics_view
+                .last_or_default()
+                .explicit_repr(index)
+                // panic should never happen as index should never be greater than cardinality:
+                .expect("Invalid index when building dataframe");
+
+            let ds_style = Style::default().fg(COLORS[index % COLORS.len()]);
+
+            Dataset::default()
+                .name(name)
+                .marker(symbols::Marker::Braille)
+                .graph_type(GraphType::Line)
+                .style(ds_style)
+                .data(data)
+        })
+        .collect()
 }
 
-impl<'a> DataFrame<'a> {
-    pub fn new(metrics_view: &'a MetricView) -> Self {
-        Self {
-            metrics_view,
-            data: Self::extract_raw_from_metrics(metrics_view),
-        }
-    }
+fn build_raw_vecs(metrics_view: &MetricView) -> Vec<Vec<(f64, f64)>> {
+    let mut data_vecs: Vec<_> = Vec::new();
+    let metrics_cardinality = metrics_view.last_or_default().cardinality();
 
-    /// Returns datasets built from the metric view
-    /// Each dataset in the returned `Vec` corresponds to one dimension of the metrics
-    pub fn datasets(&self) -> Vec<Dataset> {
-        const COLORS: [Color; 2] = [Color::Blue, Color::Green];
+    let last_iter = metrics_view.last_iteration();
 
-        self.data
+    for dimension_idx in 0..metrics_cardinality {
+        let data: Vec<_> = metrics_view
+            .as_slice()
             .iter()
+            .rev()
+            .map(|m| m.as_f64(dimension_idx).expect("Error accessing raw metric value"))
             .enumerate()
-            .map(|(index, data)| {
-                let name = self
-                    .metrics_view
-                    .last_or_default()
-                    .explicit_repr(index)
-                    // panic should never happen as index should never be greater than cardinality:
-                    .expect("Invalid index when building dataframe");
+            .map(|(idx, raw_value)| ((last_iter - idx) as f64, raw_value))
+            .rev()
+            .collect();
 
-                let ds_style = Style::default().fg(COLORS[index % COLORS.len()]);
-
-                Dataset::default()
-                    .name(name)
-                    .marker(symbols::Marker::Braille)
-                    .graph_type(GraphType::Line)
-                    .style(ds_style)
-                    .data(data)
-            })
-            .collect()
+        data_vecs.push(data);
     }
 
-    /// Extract raw data from a collection of metrics
-    /// Raw data consists of sets of (f64, f64) tuples, each set corresponding to a drawable
-    /// `Dataset`
-    fn extract_raw_from_metrics(metrics_view: &MetricView) -> Vec<Vec<(f64, f64)>> {
-        let mut data_vecs: Vec<_> = Vec::new();
-        let metrics_cardinality = metrics_view.last_or_default().cardinality();
+    data_vecs
+}
 
-        let last_iter = metrics_view.last_iteration();
+#[cfg(test)]
+mod test_raw_data_from_metrics_view {
+    use crate::core::iteration::{Iteration, Span};
+    use crate::core::metrics::{IOMetric, Metric};
+    use crate::core::view::MetricView;
+    use crate::ui::chart::build_raw_vecs;
 
-        for dimension_idx in 0..metrics_cardinality {
-            let data: Vec<_> = metrics_view
-                .as_slice()
-                .iter()
-                .rev()
-                .map(|m| m.as_f64(dimension_idx).expect("Error accessing raw metric value"))
-                .enumerate()
-                .map(|(idx, raw_value)| ((last_iter - idx) as f64, raw_value))
-                .rev()
-                .collect();
+    #[test]
+    fn test_should_assign_correct_iteration_to_each_metric() {
+        let metrics_data = vec![IOMetric::new(10, 20), IOMetric::new(30, 40)];
+        let default = IOMetric::default();
 
-            data_vecs.push(data);
-        }
+        let dyn_metrics_vec = metrics_data.iter().map(|m| m as &dyn Metric).collect();
+        let metrics_view = MetricView::new(dyn_metrics_vec, &default, Span::from_end_and_size(10, 10), 8);
+        let raw_vecs = build_raw_vecs(&metrics_view);
 
-        data_vecs
-    }
+        let expected_raw_vecs = vec![vec![(7.0, 10.0), (8.0, 30.0)], vec![(7.0, 20.0), (8.0, 40.0)]];
 
-    pub fn max_value(&self) -> f64 {
-        self.metrics_view.max_f64()
+        assert_eq!(raw_vecs, expected_raw_vecs);
     }
 }

--- a/src/ui/chart.rs
+++ b/src/ui/chart.rs
@@ -119,7 +119,7 @@ mod test_raw_data_from_metrics_view {
         let default = IOMetric::default();
 
         let dyn_metrics_vec = metrics_data.iter().map(|m| m as &dyn Metric).collect();
-        let metrics_view = MetricView::new(dyn_metrics_vec, &default, Span::from_end_and_size(10, 10), 7);
+        let metrics_view = MetricView::new(dyn_metrics_vec, &default, Span::new(0, 10), 7);
         let raw_vecs = build_raw_vecs(&metrics_view);
 
         let expected_raw_vecs = vec![vec![(7.0, 10.0), (8.0, 30.0)], vec![(7.0, 20.0), (8.0, 40.0)]];

--- a/src/ui/chart.rs
+++ b/src/ui/chart.rs
@@ -1,11 +1,10 @@
-use tui::layout::Rect;
 use tui::style::{Color, Style};
+use tui::symbols;
 use tui::text::Span;
 use tui::widgets::{Axis, Block, Borders, Chart, Dataset, GraphType};
-use tui::{symbols, Frame};
 
 use crate::core::view::MetricView;
-use crate::ui::terminal::TuiBackend;
+use crate::ui::terminal::FrameRegion;
 
 pub struct MetricsChart {}
 
@@ -16,8 +15,7 @@ impl Default for MetricsChart {
 }
 
 impl MetricsChart {
-    // TODO refactor frame and chunk are always passed together. Merge them in a struct with a render_widget method
-    pub fn render(&self, frame: &mut Frame<TuiBackend>, chunk: Rect, metrics_view: &MetricView) {
+    pub fn render(&self, frame: &mut FrameRegion, metrics_view: &MetricView) {
         let data_frame = DataFrame::new(metrics_view);
 
         let chart = Chart::new(data_frame.datasets())
@@ -25,7 +23,7 @@ impl MetricsChart {
             .x_axis(self.define_x_axis(metrics_view))
             .y_axis(self.define_y_axis(&data_frame, metrics_view.max_concise_repr(), metrics_view.unit()));
 
-        frame.render_widget(chart, chunk);
+        frame.render_widget(chart);
     }
 
     fn define_x_axis(&self, metrics_view: &MetricView) -> Axis {

--- a/src/ui/chart.rs
+++ b/src/ui/chart.rs
@@ -71,7 +71,7 @@ fn build_datasets<'a>(raw_data: &'a [Vec<(f64, f64)>], metrics_view: &MetricView
                 // panic should never happen as index should never be greater than cardinality:
                 .expect("Invalid index when building dataframe");
 
-            let ds_style = Style::default().fg(COLORS[index % COLORS.len()]);
+            let ds_style = Style::default().fg(COLORS[index]);
 
             Dataset::default()
                 .name(name)

--- a/src/ui/chart.rs
+++ b/src/ui/chart.rs
@@ -36,9 +36,9 @@ impl MetricsChart {
         Axis::default()
             .style(Style::default().fg(Color::White))
             .bounds([
-                // We do not use span.begin() here, as it has a min value of 0. On application startup, the bounds
+                // We do not use span.begin() here, as it has a min value of 0. On application startup, the chart
                 // would be squashed between 0 and span.end() until span.end() would be greater than span.size()
-                metrics_view.span().end() as f64 - metrics_view.span().size() as f64,
+                metrics_view.span().end() as f64 - metrics_view.span().size() as f64 + 1.,
                 metrics_view.span().end() as f64,
             ])
             .labels(labels)

--- a/src/ui/chart.rs
+++ b/src/ui/chart.rs
@@ -36,9 +36,7 @@ impl MetricsChart {
         Axis::default()
             .style(Style::default().fg(Color::White))
             .bounds([
-                // We do not use span.begin() here, as it has a min value of 0. On application startup, the chart
-                // would be squashed between 0 and span.end() until span.end() would be greater than span.size()
-                metrics_view.span().end() as f64 - metrics_view.span().size() as f64 + 1.,
+                metrics_view.span().signed_begin() as f64,
                 metrics_view.span().end() as f64,
             ])
             .labels(labels)

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -1,7 +1,4 @@
 use tui::layout::{Constraint, Direction, Layout, Rect};
-use tui::Frame;
-
-use crate::ui::terminal::TuiBackend;
 
 pub struct UiLayout {
     main_chunks: Vec<Rect>,
@@ -9,7 +6,7 @@ pub struct UiLayout {
 }
 
 impl UiLayout {
-    pub fn new(frame: &Frame<TuiBackend>) -> Self {
+    pub fn new(region: Rect) -> Self {
         let main_chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints(
@@ -20,7 +17,7 @@ impl UiLayout {
                 ]
                 .as_ref(),
             )
-            .split(frame.size());
+            .split(region);
 
         let center_chunks = Layout::default()
             .direction(Direction::Horizontal)

--- a/src/ui/metadata.rs
+++ b/src/ui/metadata.rs
@@ -1,11 +1,9 @@
-use tui::layout::Rect;
 use tui::style::{Color, Style};
 use tui::text::Span;
 use tui::widgets::Paragraph;
-use tui::Frame;
 
 use crate::core::process::ProcessMetadata;
-use crate::ui::terminal::TuiBackend;
+use crate::ui::terminal::FrameRegion;
 
 pub struct MetadataBar {
     current_text: String,
@@ -37,8 +35,8 @@ impl MetadataBar {
         self.current_text = Self::build_text(process_data);
     }
 
-    pub fn render(&self, frame: &mut Frame<TuiBackend>, chunk: Rect) {
+    pub fn render(&self, frame: &mut FrameRegion) {
         let paragraph = self.build_paragraph();
-        frame.render_widget(paragraph, chunk);
+        frame.render_widget(paragraph);
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -46,15 +46,19 @@ impl SpvUI {
     }
 
     pub fn render(&mut self, metrics_overview: &MetricsOverview, metrics_view: &MetricView) -> Result<(), Error> {
-        self.terminal.draw(|mut frame| {
-            let layout = UiLayout::new(frame);
+        self.terminal.draw(|frame_region| {
+            let layout = UiLayout::new(frame_region.region());
 
-            self.tabs.render(&mut frame, layout.tabs_chunk());
+            self.tabs.render(frame_region.with_region(layout.tabs_chunk()));
 
             self.process_list
-                .render(&mut frame, layout.processes_chunk(), metrics_overview);
-            self.chart.render(&mut frame, layout.chart_chunk(), metrics_view);
-            self.metadata_bar.render(&mut frame, layout.metadata_chunk());
+                .render(frame_region.with_region(layout.processes_chunk()), metrics_overview);
+
+            self.chart
+                .render(frame_region.with_region(layout.chart_chunk()), metrics_view);
+
+            self.metadata_bar
+                .render(frame_region.with_region(layout.metadata_chunk()));
         })
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -45,20 +45,20 @@ impl SpvUI {
         })
     }
 
-    pub fn render(&mut self, metrics_overview: &MetricsOverview, metrics_view: &MetricView) -> Result<(), Error> {
-        self.terminal.draw(|frame_region| {
-            let layout = UiLayout::new(frame_region.region());
+    pub fn render(&mut self, overview: &MetricsOverview, view: &Option<MetricView>) -> Result<(), Error> {
+        self.terminal.draw(|frame| {
+            let layout = UiLayout::new(frame.region());
 
-            self.tabs.render(frame_region.with_region(layout.tabs_chunk()));
+            self.tabs.render(frame.with_region(layout.tabs_chunk()));
 
             self.process_list
-                .render(frame_region.with_region(layout.processes_chunk()), metrics_overview);
+                .render(frame.with_region(layout.processes_chunk()), overview);
 
-            self.chart
-                .render(frame_region.with_region(layout.chart_chunk()), metrics_view);
+            if let Some(view) = view {
+                self.chart.render(frame.with_region(layout.chart_chunk()), view);
+            }
 
-            self.metadata_bar
-                .render(frame_region.with_region(layout.metadata_chunk()));
+            self.metadata_bar.render(frame.with_region(layout.metadata_chunk()));
         })
     }
 

--- a/src/ui/tabs.rs
+++ b/src/ui/tabs.rs
@@ -1,10 +1,8 @@
-use tui::layout::Rect;
 use tui::style::{Color, Style};
 use tui::text::Spans;
 use tui::widgets::Tabs;
-use tui::Frame;
 
-use crate::ui::terminal::TuiBackend;
+use crate::ui::terminal::FrameRegion;
 
 pub struct MetricTabs {
     selected_index: usize,
@@ -19,7 +17,7 @@ impl MetricTabs {
         }
     }
 
-    pub fn render(&self, frame: &mut Frame<TuiBackend>, chunk: Rect) {
+    pub fn render(&self, frame: &mut FrameRegion) {
         let tabs_spans = self.tabs.iter().cloned().map(Spans::from).collect();
 
         let tabs = Tabs::new(tabs_spans)
@@ -28,7 +26,7 @@ impl MetricTabs {
             .divider("|")
             .select(self.selected_index);
 
-        frame.render_widget(tabs, chunk);
+        frame.render_widget(tabs);
     }
 
     pub fn current(&self) -> &str {

--- a/src/ui/terminal.rs
+++ b/src/ui/terminal.rs
@@ -45,9 +45,9 @@ impl Terminal {
             .map_err(Error::IOError)
     }
 
-    fn render_on_frame<'a, 'b: 'a, F>(mut frame: &'a mut Frame<'b, TuiBackend>, render_fn: F)
+    fn render_on_frame<F>(mut frame: &mut Frame<TuiBackend>, render_fn: F)
     where
-        for<'f, 'g> F: FnOnce(&'f mut FrameRegion<'f, 'g>),
+        for<'a, 'b> F: FnOnce(&'a mut FrameRegion<'a, 'b>),
     {
         let mut frame_region = FrameRegion::new(&mut frame);
         render_fn(&mut frame_region);

--- a/src/ui/terminal.rs
+++ b/src/ui/terminal.rs
@@ -4,6 +4,8 @@ use std::io::Stdout;
 use log::error;
 use termion::raw::{IntoRawMode, RawTerminal};
 use tui::backend::TermionBackend;
+use tui::layout::Rect;
+use tui::widgets::{StatefulWidget, Widget};
 use tui::{Frame, Terminal as TuiTerminal};
 
 use crate::ui::Error;
@@ -33,11 +35,22 @@ impl Terminal {
         print!("{}", "\n".repeat(terminal.get_frame().size().height as usize));
     }
 
-    pub fn draw<F>(&mut self, f: F) -> Result<(), Error>
+    pub fn draw<F>(&mut self, render_fn: F) -> Result<(), Error>
     where
-        F: FnOnce(&mut Frame<TuiBackend>),
+        for<'f, 'g> F: FnOnce(&'f mut FrameRegion<'f, 'g>),
     {
-        self.tui_terminal.draw(f).map(|_frame| ()).map_err(Error::IOError)
+        self.tui_terminal
+            .draw(|mut frame| Self::render_on_frame(&mut frame, render_fn))
+            .map(|_frame| ())
+            .map_err(Error::IOError)
+    }
+
+    fn render_on_frame<'a, 'b: 'a, F>(mut frame: &'a mut Frame<'b, TuiBackend>, render_fn: F)
+    where
+        for<'f, 'g> F: FnOnce(&'f mut FrameRegion<'f, 'g>),
+    {
+        let mut frame_region = FrameRegion::new(&mut frame);
+        render_fn(&mut frame_region);
     }
 }
 
@@ -46,5 +59,39 @@ impl Drop for Terminal {
         if let Err(e) = self.tui_terminal.clear() {
             error!("Error clearing terminal: {}", e);
         }
+    }
+}
+
+pub struct FrameRegion<'a, 'b: 'a> {
+    frame: &'a mut Frame<'b, TuiBackend>,
+    region: Rect,
+}
+
+impl<'a, 'b: 'a> FrameRegion<'a, 'b> {
+    pub fn new(frame: &'a mut Frame<'b, TuiBackend>) -> Self {
+        let region = frame.size();
+        FrameRegion { frame, region }
+    }
+    pub fn render_widget<W>(&mut self, widget: W)
+    where
+        W: Widget,
+    {
+        self.frame.render_widget(widget, self.region);
+    }
+
+    pub fn render_stateful_widget<W>(&mut self, widget: W, state: &mut W::State)
+    where
+        W: StatefulWidget,
+    {
+        self.frame.render_stateful_widget(widget, self.region, state);
+    }
+
+    pub fn region(&self) -> Rect {
+        self.region
+    }
+
+    pub fn with_region(&mut self, region: Rect) -> &mut Self {
+        self.region = region;
+        self
     }
 }


### PR DESCRIPTION
This PR refactors multiple sections of the code:
- We now keep track of metric's and process's ages through an iteration counter, not a timestamp
- The scope of rendered metrics is now represented by a `Span` struct
- `MetricView` has been simplified and does not directly keep track of the current iteration anymore
- In the ui module, the `DataFrame` struct has been replaced by functions
- In the ui module, the frame and chunk parameters have been regrouped in a `FrameRegion` struct