### PR TITLE
Stabilize chart rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,9 @@ checksum = "4f67931368edf3a9a51d29886d245f1c3db2f1ef0dcc9e35ff70341b78c10d23"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "byteorder"
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "f98a04dce437184842841303488f70d0188c5f51437d2a834dc097eafa909a01"
 
 [[package]]
 name = "log"
@@ -394,7 +394,7 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -674,7 +674,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39c8ce4e27049eed97cfa363a5048b09d995e209994634a0efc26a14ab6c0c23"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags 1.3.2",
  "cassowary",
  "termion",
  "unicode-segmentation",

--- a/src/procfs/cpu_probe.rs
+++ b/src/procfs/cpu_probe.rs
@@ -99,16 +99,15 @@ impl UsageCalculator {
         self.prev_global_stat = stat_data;
     }
 
-    ///
-    /// Given new content of /proc/[pid]/stat and its last known content, calculates the elapsed
+    /// Given new content of /proc/\[pid\]/stat and its last known content, calculates the elapsed
     /// ticks corresponding to CPU runtime related to this process
     ///
-    /// Then given a recently calculated global CPU runtime lapse (see [compute_new_runtime_diff()]),
+    /// Then given a recently calculated global CPU runtime lapse (see [`Self::compute_new_runtime_diff()`]),
     /// calculates the portion of this runtime that was dedicated to the given process in percent
     ///
     /// # Arguments
     ///  * `pid` The ID of a process
-    ///  * `pid_stat_data`: The new content of the stat file of the process with ID [pid]
+    ///  * `pid_stat_data`: The new content of the stat file of the process with ID `pid`
     ///
     pub fn calculate_pid_usage(&mut self, pid: Pid, pid_stat_data: PidStat) -> f64 {
         let last_iter_runtime = match self.processes_prev_stats.get(&pid) {
@@ -218,7 +217,7 @@ mod test_cpu_probe {
     }
 
     #[test]
-    fn test_should_return_ignore_pid_when_probe_returns_err() {
+    fn test_should_ignore_pid_when_probe_returns_err() {
         let stat_reader = InMemoryStatReader {
             stat_seq: vec![create_stat(0), create_stat(200)],
         };

--- a/src/ui/chart.rs
+++ b/src/ui/chart.rs
@@ -55,6 +55,9 @@ impl MetricsChart {
 
         let labels = vec![
             Span::from("0"),
+            // To keep the first X-axis label from resizing the chart when its length changes:
+            // TODO remove this once issue #567 from tui-rs is solved (or PR #568 is merged)
+            Span::from("           "),
             Span::from(metrics_view.concise_repr_of_value(upper_bound)),
         ];
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -57,9 +57,7 @@ impl SpvUI {
             self.process_list
                 .render(frame.with_region(layout.processes_chunk()), overview);
 
-            if let Some(view) = view {
-                self.chart.render(frame.with_region(layout.chart_chunk()), view);
-            }
+            self.chart.render(frame.with_region(layout.chart_chunk()), view);
 
             self.metadata_bar.render(frame.with_region(layout.metadata_chunk()));
         })


### PR DESCRIPTION
- The borders of the chart area are now correctly rendered even if no process is selected
- The width of the graph area of the chart should not change depending on the date of the metrics points