### PR TITLE
Resize chart span

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,60 +3,16 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55f82cfe485775d02112886f4169bde0c5894d75e79ead7eafe7e40a25e45f7"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
-name = "aho-corasick"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
-
-[[package]]
-name = "backtrace"
-version = "0.3.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d117600f438b1707d4e4ae15d3595657288f8235a0eb593e80ecc98ab34e1bc"
-dependencies = [
- "addr2line",
- "cfg-if 1.0.0",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
-
-[[package]]
-name = "bitflags"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f67931368edf3a9a51d29886d245f1c3db2f1ef0dcc9e35ff70341b78c10d23"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
@@ -65,22 +21,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
-name = "cfg-if"
-version = "0.1.10"
+name = "cc"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -89,138 +39,207 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.19"
+name = "errno"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
+ "errno-dragonfly",
  "libc",
- "num-integer",
- "num-traits",
- "time",
- "winapi 0.3.9",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
-name = "error-chain"
-version = "0.12.4"
+name = "errno-dragonfly"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
- "backtrace",
- "version_check",
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.13",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
+name = "futures-util"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi",
 ]
 
 [[package]]
-name = "gimli"
-version = "0.23.0"
+name = "hermit-abi"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
-name = "glob"
-version = "0.2.11"
+name = "instant"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-
-[[package]]
-name = "ipnetwork"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8eca9f51da27bc908ef3dd85c21e1bbba794edaf94d7841e37356275b82d31e"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "serde",
+ "cfg-if",
 ]
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
+name = "io-lifetimes"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
- "winapi 0.2.8",
- "winapi-build",
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "libc"
-version = "0.2.109"
+version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98a04dce437184842841303488f70d0188c5f51437d2a834dc097eafa909a01"
+checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
 
 [[package]]
 name = "log"
-version = "0.3.9"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "log 0.4.11",
-]
-
-[[package]]
-name = "log"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
-dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.4.4"
+name = "num_threads"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
 dependencies = [
- "adler",
- "autocfg",
-]
-
-[[package]]
-name = "netinfo"
-version = "0.5.1"
-source = "git+https://github.com/theogilbert/netinfo?branch=fixed#3a850f9cb15a8a4c73a234b2bf4679787cf974c5"
-dependencies = [
- "byteorder",
- "error-chain",
- "log 0.4.11",
- "pnet",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
-dependencies = [
- "autocfg",
+ "libc",
 ]
 
 [[package]]
@@ -230,141 +249,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 
 [[package]]
-name = "object"
-version = "0.23.0"
+name = "pin-project-lite"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
-name = "pnet"
-version = "0.26.0"
+name = "pin-utils"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df42dcd72f6f2a658bcf38509f1027df1440ac85f1af4badbe034418302dc"
-dependencies = [
- "ipnetwork",
- "pnet_base",
- "pnet_datalink",
- "pnet_packet",
- "pnet_sys",
- "pnet_transport",
-]
-
-[[package]]
-name = "pnet_base"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cd5f7e15220afa66b0a9a62841ea10089f39dcaa1c29752c0b22dfc03111b5"
-
-[[package]]
-name = "pnet_datalink"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7318ae1d6e0b7fa1e49933233c9473f2b72d3d18b97e70e2716c6415dde5f915"
-dependencies = [
- "ipnetwork",
- "libc",
- "pnet_base",
- "pnet_sys",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "pnet_macros"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbd5c52c6e04aa720400f9c71cd0e8bcb38cd13421d5caabd9035e9efa47de9"
-dependencies = [
- "regex",
- "syntex",
- "syntex_syntax",
-]
-
-[[package]]
-name = "pnet_macros_support"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf9c5c0c36766d0a4da9ab268c0700771b8ec367b9463fd678109fa28463c5b"
-dependencies = [
- "pnet_base",
-]
-
-[[package]]
-name = "pnet_packet"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e26a864d71d0ac51a549cf40283c44ed1b8f98168545638a4730ef9f560283"
-dependencies = [
- "glob",
- "pnet_base",
- "pnet_macros",
- "pnet_macros_support",
- "syntex",
-]
-
-[[package]]
-name = "pnet_sys"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f0de0c52609f157b25d79ce24d9016ab1bbf10cde761397200d634a833872c"
-dependencies = [
- "libc",
- "winapi 0.2.8",
- "ws2_32-sys",
-]
-
-[[package]]
-name = "pnet_transport"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6712ab76534340494d849e3c51c64a6261e4b451337b7c05bd3681e384c48b10"
-dependencies = [
- "libc",
- "pnet_base",
- "pnet_packet",
- "pnet_sys",
-]
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
- "unicode-xid 0.2.1",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
- "rand_hc",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -372,29 +307,29 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.3.0"
+name = "redox_syscall"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "rand_core",
+ "bitflags",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
 ]
 
 [[package]]
@@ -403,59 +338,34 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
 dependencies = [
- "redox_syscall",
-]
-
-[[package]]
-name = "regex"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi 0.3.9",
+ "redox_syscall 0.2.16",
 ]
 
 [[package]]
 name = "rstest"
-version = "0.11.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2288c66aeafe3b2ed227c981f364f9968fa952ef0b30e84ada4486e7ee24d00a"
+checksum = "b07f2d176c472198ec1e6551dc7da28f1c089652f66a7b722676c2238ebc0edf"
 dependencies = [
- "cfg-if 1.0.0",
- "proc-macro2",
- "quote",
+ "futures",
+ "futures-timer",
+ "rstest_macros",
  "rustc_version",
- "syn",
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.21"
+name = "rstest_macros"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+checksum = "7229b505ae0706e64f37ffc54a9c163e11022a6636d58fe1f3f52018257ff9f7"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.109",
+ "unicode-ident",
+]
 
 [[package]]
 name = "rustc_version"
@@ -467,22 +377,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.4"
+name = "rustix"
+version = "0.37.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.130"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.10"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c98891d737e271a2954825ef19e46bd16bdb98e2746f2eec4f7a4ef7946efd1"
+checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -490,22 +414,31 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "simplelog"
-version = "0.10.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85d04ae642154220ef00ee82c36fb07853c10a4f2a0ca6719f9991211d2eb959"
+checksum = "acee08041c5de3d5048c8b3f6f13fafb3026b24ba43c6a695a0c76179b844369"
 dependencies = [
- "chrono",
- "log 0.4.11",
+ "log",
  "termcolor",
+ "time",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -520,8 +453,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "libc",
- "log 0.4.11",
- "netinfo",
+ "log",
  "rand",
  "rstest",
  "signal-hook",
@@ -535,93 +467,44 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.76"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid 0.2.1",
+ "unicode-ident",
 ]
 
 [[package]]
-name = "syntex"
-version = "0.42.2"
+name = "syn"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a30b08a6b383a22e5f6edc127d169670d48f905bb00ca79a00ea3e442ebe317"
+checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
 dependencies = [
- "syntex_errors",
- "syntex_syntax",
-]
-
-[[package]]
-name = "syntex_errors"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c48f32867b6114449155b2a82114b86d4b09e1bddb21c47ff104ab9172b646"
-dependencies = [
- "libc",
- "log 0.3.9",
- "rustc-serialize",
- "syntex_pos",
- "term",
- "unicode-xid 0.0.3",
-]
-
-[[package]]
-name = "syntex_pos"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd49988e52451813c61fecbe9abb5cfd4e1b7bb6cdbb980a6fbcbab859171a6"
-dependencies = [
- "rustc-serialize",
-]
-
-[[package]]
-name = "syntex_syntax"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7628a0506e8f9666fdabb5f265d0059b059edac9a3f810bda077abb5d826bd8d"
-dependencies = [
- "bitflags 0.5.0",
- "libc",
- "log 0.3.9",
- "rustc-serialize",
- "syntex_errors",
- "syntex_pos",
- "term",
- "unicode-xid 0.0.3",
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "rand",
- "redox_syscall",
- "remove_dir_all",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "term"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
-dependencies = [
- "kernel32-sys",
- "winapi 0.2.8",
+ "cfg-if",
+ "fastrand",
+ "redox_syscall 0.3.5",
+ "rustix",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
@@ -634,48 +517,66 @@ checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
 dependencies = [
  "libc",
  "numtoa",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "redox_termios",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.29"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.29"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
+ "itoa",
  "libc",
- "wasi",
- "winapi 0.3.9",
+ "num_threads",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]
 name = "tui"
-version = "0.16.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c8ce4e27049eed97cfa363a5048b09d995e209994634a0efc26a14ab6c0c23"
+checksum = "ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "cassowary",
  "termion",
  "unicode-segmentation",
@@ -683,46 +584,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
+name = "unicode-ident"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
-name = "unicode-xid"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36dff09cafb4ec7c8cf0023eb0b686cb6ce65499116a12201c9e11840ca01beb"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
-
-[[package]]
-name = "version_check"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"
@@ -733,12 +616,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -752,7 +629,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -762,11 +639,133 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
+name = "windows-sys"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "winapi 0.2.8",
- "winapi-build",
+ "windows-targets 0.42.2",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "Command line utility to supervize resource usage of processes"
 license = "MIT"
 
 [features]
-netio = ["netinfo"]
+# netio = ["netinfo"]
 
 [dependencies]
 tui = { version = "0.19", default-features = false, features = ["termion"] }
@@ -20,11 +20,11 @@ anyhow = "1.0.44"
 libc = "0.2.108"
 # This will have to stay this way until https://github.com/kaegi/netinfo/pull/5 is merged and a new version is produced
 #netinfo = { version = "0.5.1", optional = true }
-netinfo = { git = "https://github.com/theogilbert/netinfo", branch = "fixed", optional = true }
+#netinfo = { git = "https://github.com/theogilbert/netinfo", branch = "fixed", optional = true }
 
 [dev-dependencies]
 tempfile = "3.2.0"
-rstest = "0.11.0"
+rstest = "0.16.0"
 sn_fake_clock = "0.4.14"
 rand = "0.8.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ netio = ["netinfo"]
 tui = { version = "0.19", default-features = false, features = ["termion"] }
 termion = "1.5.6"
 log = { version = " 0.4", features = ["max_level_debug", "release_max_level_info"] }
-simplelog = "0.10.0"
+simplelog = "0.12.0"
 signal-hook = "0.3.10"
 thiserror = "1.0.29"
 anyhow = "1.0.44"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 netio = ["netinfo"]
 
 [dependencies]
-tui = "0.16.0"
+tui = { version = "0.19", default-features = false, features = ["termion"] }
 termion = "1.5.6"
 log = { version = " 0.4", features = ["max_level_debug", "release_max_level_info"] }
 simplelog = "0.10.0"

--- a/src/core/collection.rs
+++ b/src/core/collection.rs
@@ -252,8 +252,7 @@ where
     pub fn last_or_default(&self, pid: Pid) -> &M {
         self.processes_data
             .get(&pid)
-            .map(|pd| pd.last())
-            .flatten()
+            .and_then(|pd| pd.last())
             .unwrap_or(&self.default)
     }
 

--- a/src/core/collection.rs
+++ b/src/core/collection.rs
@@ -344,7 +344,6 @@ where
 
     /** Builds and returns a sorted list of dated metrics who are included in the span, or adjacent to this span **/
     fn extract_metrics_around_span(&self, span: &Span) -> Vec<DatedMetric> {
-        // TODO remove RenderingSpan tolerance made obsolete by adjacent metrics being returned
         return self
             .metrics
             .iter()

--- a/src/core/metrics.rs
+++ b/src/core/metrics.rs
@@ -167,7 +167,7 @@ mod test_percent_metric {
 }
 
 /// Metric representing input / output bitrates (e.g. network throughput) in bytes/sec
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub struct IOMetric {
     input: usize,
     output: usize,

--- a/src/core/metrics.rs
+++ b/src/core/metrics.rs
@@ -86,12 +86,12 @@ impl<'a> DatedMetric<'a> {
 /// Metric representing a percent value (e.g. CPU usage)
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub struct PercentMetric {
-    percent_usage: f64,
+    value: f64,
 }
 
 impl PercentMetric {
     pub fn new(percent_usage: f64) -> Self {
-        Self { percent_usage }
+        Self { value: percent_usage }
     }
 }
 
@@ -109,13 +109,13 @@ impl Metric for PercentMetric {
 
     fn as_f64(&self, index: usize) -> Result<f64, Error> {
         match index {
-            0 => Ok(self.percent_usage),
+            0 => Ok(self.value),
             _ => Err(Error::RawMetricAccessError(index, self.cardinality())),
         }
     }
 
     fn max_value(&self) -> f64 {
-        self.percent_usage
+        self.value
     }
 
     fn unit(&self) -> &'static str {
@@ -123,7 +123,7 @@ impl Metric for PercentMetric {
     }
 
     fn concise_repr(&self) -> String {
-        self.concise_repr_of_value(self.percent_usage)
+        self.concise_repr_of_value(self.value)
     }
 
     fn concise_repr_of_value(&self, value: f64) -> String {
@@ -132,7 +132,7 @@ impl Metric for PercentMetric {
 
     fn explicit_repr(&self, index: usize) -> Result<String, Error> {
         match index {
-            0 => Ok(format!("Usage {:.2}%", self.percent_usage)),
+            0 => Ok(format!("Usage {:.2}%", self.value)),
             _ => Err(Error::RawMetricAccessError(index, self.cardinality())),
         }
     }
@@ -140,7 +140,7 @@ impl Metric for PercentMetric {
 
 impl PartialOrd for PercentMetric {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.percent_usage.partial_cmp(&other.percent_usage)
+        self.value.partial_cmp(&other.value)
     }
 }
 

--- a/src/core/ordering.rs
+++ b/src/core/ordering.rs
@@ -26,7 +26,7 @@ pub const PROCESS_ORDERING_CRITERIA: [ProcessOrdering; 3] = [
 ///
 /// Regardless of the criteria, running processes are displayed before dead processes
 pub fn sort_processes(
-    processes: &mut Vec<ProcessMetadata>,
+    processes: &mut [ProcessMetadata],
     criteria: ProcessOrdering,
     current_collector: &dyn MetricCollector,
 ) {

--- a/src/core/time.rs
+++ b/src/core/time.rs
@@ -229,8 +229,23 @@ impl Span {
         Span { begin, end }
     }
 
+    /// Updates the begining value of the span without updating its end
+    /// After this operation, the `end` value of the span will remain the same.
+    ///
+    /// This method panics if `begin` is greater than `end`.
+    ///
+    /// # Arguments
+    /// * `begin`: The first timestamp covered by the span
+
+    pub fn set_begin_and_resize(&mut self, begin: Timestamp) {
+        if begin > self.end {
+            panic!("Invalid begin for span {:?}: {:?}", self, begin);
+        }
+        self.begin = begin;
+    }
+
     /// Updates the end of the span without updating the begining of the span
-    /// After this operation, the `begin` iteration of the span will remain the same.
+    /// After this operation, the `begin` value of the span will remain the same.
     ///
     /// This method panics if `end` is less than `begin`.
     ///
@@ -324,6 +339,21 @@ mod test_span {
         assert_eq!(span.end(), original_span.end() + Duration::from_secs(120));
         assert_eq!(span.duration(), Duration::from_secs(60));
     }
+
+    #[test]
+    fn test_should_update_span_when_setting_begin_and_updating_size() {
+        setup_fake_clock_to_prevent_substract_overflow();
+
+        let mut span = Span::from_duration(Duration::from_secs(10));
+        let original_span = span;
+
+        span.set_begin_and_resize(span.begin() + Duration::from_secs(3));
+
+        assert_eq!(span.begin(), original_span.begin() + Duration::from_secs(3));
+        assert_eq!(span.end(), original_span.end());
+        assert_eq!(span.duration(), Duration::from_secs(7));
+    }
+
 
     #[test]
     fn test_should_update_span_when_setting_end_and_updating_size() {

--- a/src/core/time.rs
+++ b/src/core/time.rs
@@ -305,8 +305,8 @@ mod test_span {
 
     use rstest::*;
 
-    use crate::core::time::test_utils::setup_fake_clock_to_prevent_substract_overflow;
     use crate::core::time::{Span, Timestamp};
+    use crate::core::time::test_utils::setup_fake_clock_to_prevent_substract_overflow;
 
     #[test]
     fn test_should_correctly_define_span_when_creating_from_begin() {
@@ -401,9 +401,9 @@ mod test_span {
     }
 
     #[rstest]
-    #[case(-10, 10)]
+    #[case(- 10, 10)]
     #[case(0, 10)]
-    #[case(-10, 0)]
+    #[case(- 10, 0)]
     fn test_should_return_true_if_timestamp_contained_in_span(#[case] relative_begin: i64, #[case] relative_end: u64) {
         setup_fake_clock_to_prevent_substract_overflow();
         let timestamp = Timestamp::now();

--- a/src/core/time.rs
+++ b/src/core/time.rs
@@ -305,8 +305,8 @@ mod test_span {
 
     use rstest::*;
 
-    use crate::core::time::{Span, Timestamp};
     use crate::core::time::test_utils::setup_fake_clock_to_prevent_substract_overflow;
+    use crate::core::time::{Span, Timestamp};
 
     #[test]
     fn test_should_correctly_define_span_when_creating_from_begin() {
@@ -353,7 +353,6 @@ mod test_span {
         assert_eq!(span.end(), original_span.end());
         assert_eq!(span.duration(), Duration::from_secs(7));
     }
-
 
     #[test]
     fn test_should_update_span_when_setting_end_and_updating_size() {

--- a/src/core/time.rs
+++ b/src/core/time.rs
@@ -82,14 +82,19 @@ pub mod test_utils {
     }
 
     /// FakeClock returns a default Instant with a timestamp 0 (represented as u64) if the time is not set.
-    /// This means that substracting from Instant::now() in a test will produce a subtraction overflow, as we will try
+    /// This means that subtracting from Instant::now() in a test will produce a subtraction overflow, as we will try
     /// to produce an unsigned value under 0.
     /// To avoid this error, we configure the current time of FakeClock to a high value, so that we can safely subtract
     /// from it.
     pub fn setup_fake_clock_to_prevent_substract_overflow() {
-        refresh_current_timestamp(); // We do a first refresh to set Timestamp::app_init()
-        FakeClock::set_time(365 * 24 * 3600 * 1000);
-        refresh_current_timestamp(); // And now to actually make Timestamp::now() reflect the updated time
+        const CURRENT_MS: u64 = 365 * 24 * 3600 * 1000;
+
+        // We do a first refresh to set Timestamp::app_init() to 5 min in the past
+        FakeClock::set_time(CURRENT_MS - 300 * 1000);
+        refresh_current_timestamp();
+        // And now to actually make Timestamp::now() reflect the updated time
+        FakeClock::set_time(CURRENT_MS);
+        refresh_current_timestamp();
     }
 }
 

--- a/src/core/view.rs
+++ b/src/core/view.rs
@@ -173,7 +173,7 @@ mod test_metric_view {
     }
 }
 
-/// Overview of a single probe's latest metrics, for all running processes
+/// Overview of a single probe's latest metric, for each running processes
 ///
 /// Refer to the [`MetricCollector`](crate::core::collection::MetricCollector) trait to instanciate a `MetricsOverview`
 pub struct MetricsOverview<'a> {

--- a/src/core/view.rs
+++ b/src/core/view.rs
@@ -7,7 +7,7 @@ use crate::core::metrics::{DatedMetric, Metric};
 use crate::core::process::{Pid, ProcessMetadata};
 use crate::core::time::Span;
 
-/// Snapshot of all collected metrics of a single process, from a single probe
+/// Snapshot of a slice of collected metrics of a single process, from a single probe
 ///
 /// Refer to the [`MetricCollector`](crate::core::collection::MetricCollector) trait to instanciate a `MetricView`
 pub struct MetricView<'a> {

--- a/src/ctrl/mod.rs
+++ b/src/ctrl/mod.rs
@@ -9,7 +9,7 @@ use crate::core::view::{CollectorsView, ProcessesView};
 use crate::ctrl::collectors::Collectors;
 use crate::ctrl::processes::{ProcessSelector, SortCriteriaSelector};
 use crate::ctrl::span::RenderingSpan;
-use crate::triggers::Key;
+use crate::triggers::Input;
 
 pub mod collectors;
 pub mod processes;
@@ -52,43 +52,43 @@ impl Controls {
     /// The input will have a different effect depending on the state of the application.
     ///
     /// Returns the effect caused by the input.
-    pub fn interpret_input(&mut self, input: Key) -> Effect {
+    pub fn interpret_input(&mut self, input: Input) -> Effect {
         match self.current_state {
             State::Spv => self.interpret_spv_input(input),
             State::SortingPrompt(_) => self.interpret_sorting_prompt_input(input),
         }
     }
 
-    fn interpret_spv_input(&mut self, input: Key) -> Effect {
+    fn interpret_spv_input(&mut self, input: Input) -> Effect {
         match input {
-            Key::P => self.collectors.previous_collector(),
-            Key::N => self.collectors.next_collector(),
-            Key::Up => self.process_selector.previous_process(),
-            Key::Down => self.process_selector.next_process(),
-            Key::G => self.rendering_span.reset_scroll(),
-            Key::Left => self.rendering_span.scroll_left(),
-            Key::Right => self.rendering_span.scroll_right(),
-            Key::I => self.rendering_span.zoom_in(),
-            Key::O => self.rendering_span.zoom_out(),
-            Key::S => self.current_state = State::SortingPrompt(self.sort_criteria_selector.applied()),
+            Input::Left => self.collectors.previous_collector(),
+            Input::Right => self.collectors.next_collector(),
+            Input::Up => self.process_selector.previous_process(),
+            Input::Down => self.process_selector.next_process(),
+            Input::G => self.rendering_span.reset_scroll(),
+            Input::AltLeft => self.rendering_span.scroll_left(),
+            Input::AltRight => self.rendering_span.scroll_right(),
+            Input::AltUp => self.rendering_span.zoom_in(),
+            Input::AltDown => self.rendering_span.zoom_out(),
+            Input::S => self.current_state = State::SortingPrompt(self.sort_criteria_selector.applied()),
             _ => {}
         }
 
         Effect::None
     }
 
-    fn interpret_sorting_prompt_input(&mut self, input: Key) -> Effect {
+    fn interpret_sorting_prompt_input(&mut self, input: Input) -> Effect {
         match input {
-            Key::S | Key::Escape => self.current_state = State::Spv,
-            Key::Down => {
+            Input::S | Input::Escape => self.current_state = State::Spv,
+            Input::Down => {
                 self.sort_criteria_selector.next();
                 self.refresh_state();
             }
-            Key::Up => {
+            Input::Up => {
                 self.sort_criteria_selector.previous();
                 self.refresh_state();
             }
-            Key::Submit => {
+            Input::Submit => {
                 self.sort_criteria_selector.apply();
                 self.current_state = State::Spv;
                 return Effect::ProcessesSorted(self.sort_criteria_selector.applied());

--- a/src/ctrl/mod.rs
+++ b/src/ctrl/mod.rs
@@ -38,14 +38,10 @@ pub struct Controls {
 }
 
 impl Controls {
-    pub fn new(
-        collectors: Vec<Box<dyn MetricCollector>>,
-        initial_span_duration: Duration,
-        span_tolerance: Duration,
-    ) -> Self {
+    pub fn new(collectors: Vec<Box<dyn MetricCollector>>, initial_span_duration: Duration) -> Self {
         Self {
             collectors: Collectors::new(collectors),
-            rendering_span: RenderingSpan::new(initial_span_duration, span_tolerance),
+            rendering_span: RenderingSpan::new(initial_span_duration),
             process_selector: ProcessSelector::default(),
             sort_criteria_selector: SortCriteriaSelector::default(),
             current_state: State::Spv,

--- a/src/ctrl/mod.rs
+++ b/src/ctrl/mod.rs
@@ -72,6 +72,8 @@ impl Controls {
             Key::G => self.rendering_span.reset_scroll(),
             Key::Left => self.rendering_span.scroll_left(),
             Key::Right => self.rendering_span.scroll_right(),
+            Key::I => self.rendering_span.zoom_in(),
+            Key::O => self.rendering_span.zoom_out(),
             Key::S => self.current_state = State::SortingPrompt(self.sort_criteria_selector.applied()),
             _ => {}
         }

--- a/src/ctrl/mod.rs
+++ b/src/ctrl/mod.rs
@@ -65,13 +65,13 @@ impl Controls {
 
     fn interpret_spv_input(&mut self, input: Key) -> Effect {
         match input {
-            Key::Left => self.collectors.previous_collector(),
-            Key::Right => self.collectors.next_collector(),
+            Key::P => self.collectors.previous_collector(),
+            Key::N => self.collectors.next_collector(),
             Key::Up => self.process_selector.previous_process(),
             Key::Down => self.process_selector.next_process(),
             Key::G => self.rendering_span.reset_scroll(),
-            Key::H => self.rendering_span.scroll_left(),
-            Key::L => self.rendering_span.scroll_right(),
+            Key::Left => self.rendering_span.scroll_left(),
+            Key::Right => self.rendering_span.scroll_right(),
             Key::S => self.current_state = State::SortingPrompt(self.sort_criteria_selector.applied()),
             _ => {}
         }
@@ -81,7 +81,7 @@ impl Controls {
 
     fn interpret_sorting_prompt_input(&mut self, input: Key) -> Effect {
         match input {
-            Key::S => self.current_state = State::Spv,
+            Key::S | Key::Escape => self.current_state = State::Spv,
             Key::Down => {
                 self.sort_criteria_selector.next();
                 self.refresh_state();

--- a/src/ctrl/mod.rs
+++ b/src/ctrl/mod.rs
@@ -108,7 +108,7 @@ impl Controls {
     }
 
     pub fn refresh_span(&mut self) {
-        self.rendering_span.refresh();
+        self.rendering_span.follow();
     }
 
     pub fn to_span(&self) -> Span {

--- a/src/ctrl/processes.rs
+++ b/src/ctrl/processes.rs
@@ -203,7 +203,7 @@ impl SortCriteriaSelector {
         self.applied_selection = self.selected_index;
     }
 
-    /// Returns the critieria which is currently applied, even if it is not selected
+    /// Returns the criteria which is currently applied, even if it is not selected
     pub fn applied(&self) -> ProcessOrdering {
         PROCESS_ORDERING_CRITERIA[self.applied_selection]
     }

--- a/src/ctrl/span.rs
+++ b/src/ctrl/span.rs
@@ -22,9 +22,8 @@ impl RenderingSpan {
         }
     }
 
-    /// Refreshes the rendering span so that it keeps being scrolled to the right
-    pub fn refresh(&mut self) {
-        // TODO find a more appropriate name for the method
+    /// Shifts the rendering span so that it ends at the current time
+    pub fn follow(&mut self) {
         if self.follow {
             self.span.set_end_and_shift(Timestamp::now());
             self.set_follow_if_span_is_tracking_current_timestamp();
@@ -168,7 +167,7 @@ mod test_rendering_span {
     #[rstest]
     fn test_should_follow_when_refreshed(mut rendering_span: RenderingSpan) {
         advance_time_and_refresh_timestamp(Duration::from_secs(10));
-        rendering_span.refresh();
+        rendering_span.follow();
 
         assert_eq!(rendering_span.to_span().end(), Timestamp::now());
     }
@@ -178,7 +177,7 @@ mod test_rendering_span {
         rendering_span.scroll_left();
 
         advance_time_and_refresh_timestamp(Duration::from_secs(10));
-        rendering_span.refresh();
+        rendering_span.follow();
 
         assert_ne!(rendering_span.to_span().end(), Timestamp::now());
     }
@@ -190,7 +189,7 @@ mod test_rendering_span {
         rendering_span.scroll_right();
 
         advance_time_and_refresh_timestamp(Duration::from_secs(10));
-        rendering_span.refresh();
+        rendering_span.follow();
 
         assert_ne!(rendering_span.to_span().end(), Timestamp::now());
     }
@@ -201,7 +200,7 @@ mod test_rendering_span {
         rendering_span.scroll_right();
 
         advance_time_and_refresh_timestamp(Duration::from_secs(10));
-        rendering_span.refresh();
+        rendering_span.follow();
 
         assert_eq!(rendering_span.to_span().end(), Timestamp::now());
     }

--- a/src/ctrl/span.rs
+++ b/src/ctrl/span.rs
@@ -83,8 +83,8 @@ impl RenderingSpan {
     }
 
     pub fn zoom_in(&mut self) {
-        self.zoom_level = self.zoom_level.checked_sub(1).unwrap_or(0);
-        self.resize_from_zoom_level();
+        let new_zoom_level = self.zoom_level.checked_sub(1).unwrap_or(0);
+        self.resize(new_zoom_level);
     }
 
     pub fn zoom_out(&mut self) {
@@ -95,14 +95,14 @@ impl RenderingSpan {
         let max_zoom_level = f64::log2(max_units_to_display).ceil() as u32;
 
         if self.zoom_level < max_zoom_level {
-            self.zoom_level += 1;
-            self.resize_from_zoom_level();
+            self.resize(self.zoom_level + 1);
         }
     }
 
-    fn resize_from_zoom_level(&mut self) {
-        let target_size: Duration = Duration::from_secs(SPAN_UNIT.as_secs() * (1 << self.zoom_level));
+    fn resize(&mut self, zoom_level: u32) {
+        let target_size: Duration = Duration::from_secs(SPAN_UNIT.as_secs() * (1 << zoom_level));
         self.span.set_begin_and_resize(self.span.end() - target_size);
+        self.zoom_level = zoom_level;
     }
 }
 

--- a/src/ctrl/span.rs
+++ b/src/ctrl/span.rs
@@ -96,7 +96,7 @@ mod test_rendering_span {
     use crate::core::time::test_utils::{
         advance_time_and_refresh_timestamp, setup_fake_clock_to_prevent_substract_overflow,
     };
-    use crate::core::time::{Span, Timestamp};
+    use crate::core::time::Timestamp;
     use crate::ctrl::span::RenderingSpan;
 
     #[fixture]

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,9 +57,7 @@ fn init_logging() {
         .open("spv.log")
         .expect("Could not open log file");
 
-    let log_config = ConfigBuilder::default()
-        .set_time_format_str("%Y-%m-%d %H:%M:%S%.3f")
-        .build();
+    let log_config = ConfigBuilder::default().set_time_format_rfc2822().build();
 
     WriteLogger::init(LevelFilter::Debug, log_config, log_file).expect("Could not initialize logging");
 }

--- a/src/spv.rs
+++ b/src/spv.rs
@@ -34,7 +34,7 @@ impl SpvApplication {
             receiver,
             process_collector,
             ui: SpvUI::new(2 * impulse_tolerance)?,
-            controls: Controls::new(collectors, DEFAULT_REPRESENTED_SPAN_DURATION, 2 * impulse_tolerance),
+            controls: Controls::new(collectors, DEFAULT_REPRESENTED_SPAN_DURATION),
         })
     }
 

--- a/src/triggers/input.rs
+++ b/src/triggers/input.rs
@@ -4,7 +4,7 @@ use std::sync::mpsc::Sender;
 use termion::event::Key as TermionKey;
 use termion::input::TermRead;
 
-use crate::triggers::{Error, Key, Trigger};
+use crate::triggers::{Error, Input, Trigger};
 
 pub struct InputListener {
     sender: Sender<Trigger>,
@@ -25,11 +25,11 @@ impl InputListener {
             match key {
                 TermionKey::Ctrl(c) => self.on_ctrl_key_pressed(c),
                 TermionKey::Char(c) => self.on_key_pressed(c),
-                TermionKey::Left => self.send(Trigger::Input(Key::Left)),
-                TermionKey::Right => self.send(Trigger::Input(Key::Right)),
-                TermionKey::Up => self.send(Trigger::Input(Key::Up)),
-                TermionKey::Down => self.send(Trigger::Input(Key::Down)),
-                TermionKey::Esc => self.send(Trigger::Input(Key::Escape)),
+                TermionKey::Left => self.send(Trigger::Input(Input::Left)),
+                TermionKey::Right => self.send(Trigger::Input(Input::Right)),
+                TermionKey::Up => self.send(Trigger::Input(Input::Up)),
+                TermionKey::Down => self.send(Trigger::Input(Input::Down)),
+                TermionKey::Esc => self.send(Trigger::Input(Input::Escape)),
                 _ => (),
             }
 
@@ -51,17 +51,17 @@ impl InputListener {
     fn on_key_pressed(&mut self, key: char) {
         match key {
             'q' => self.send_exit(),
-            'h' => self.send(Trigger::Input(Key::Left)),
-            'l' => self.send(Trigger::Input(Key::Right)),
-            'g' => self.send(Trigger::Input(Key::G)),
-            's' => self.send(Trigger::Input(Key::S)),
-            'j' => self.send(Trigger::Input(Key::Down)),
-            'k' => self.send(Trigger::Input(Key::Up)),
-            'p' => self.send(Trigger::Input(Key::P)),
-            'n' => self.send(Trigger::Input(Key::N)),
-            'i' => self.send(Trigger::Input(Key::I)),
-            'o' => self.send(Trigger::Input(Key::O)),
-            '\n' => self.send(Trigger::Input(Key::Submit)),
+            'h' => self.send(Trigger::Input(Input::Left)),
+            'j' => self.send(Trigger::Input(Input::Down)),
+            'k' => self.send(Trigger::Input(Input::Up)),
+            'l' => self.send(Trigger::Input(Input::Right)),
+            'H' => self.send(Trigger::Input(Input::AltLeft)),
+            'J' => self.send(Trigger::Input(Input::AltDown)),
+            'K' => self.send(Trigger::Input(Input::AltUp)),
+            'L' => self.send(Trigger::Input(Input::AltRight)),
+            'g' => self.send(Trigger::Input(Input::G)),
+            's' => self.send(Trigger::Input(Input::S)),
+            '\n' => self.send(Trigger::Input(Input::Submit)),
             _ => {}
         };
     }

--- a/src/triggers/input.rs
+++ b/src/triggers/input.rs
@@ -59,6 +59,8 @@ impl InputListener {
             'k' => self.send(Trigger::Input(Key::Up)),
             'p' => self.send(Trigger::Input(Key::P)),
             'n' => self.send(Trigger::Input(Key::N)),
+            'i' => self.send(Trigger::Input(Key::I)),
+            'o' => self.send(Trigger::Input(Key::O)),
             '\n' => self.send(Trigger::Input(Key::Submit)),
             _ => {}
         };

--- a/src/triggers/input.rs
+++ b/src/triggers/input.rs
@@ -29,6 +29,7 @@ impl InputListener {
                 TermionKey::Right => self.send(Trigger::Input(Key::Right)),
                 TermionKey::Up => self.send(Trigger::Input(Key::Up)),
                 TermionKey::Down => self.send(Trigger::Input(Key::Down)),
+                TermionKey::Esc => self.send(Trigger::Input(Key::Escape)),
                 _ => (),
             }
 
@@ -50,10 +51,14 @@ impl InputListener {
     fn on_key_pressed(&mut self, key: char) {
         match key {
             'q' => self.send_exit(),
-            'h' => self.send(Trigger::Input(Key::H)),
-            'l' => self.send(Trigger::Input(Key::L)),
+            'h' => self.send(Trigger::Input(Key::Left)),
+            'l' => self.send(Trigger::Input(Key::Right)),
             'g' => self.send(Trigger::Input(Key::G)),
             's' => self.send(Trigger::Input(Key::S)),
+            'j' => self.send(Trigger::Input(Key::Down)),
+            'k' => self.send(Trigger::Input(Key::Up)),
+            'p' => self.send(Trigger::Input(Key::P)),
+            'n' => self.send(Trigger::Input(Key::N)),
             '\n' => self.send(Trigger::Input(Key::Submit)),
             _ => {}
         };

--- a/src/triggers/mod.rs
+++ b/src/triggers/mod.rs
@@ -28,22 +28,22 @@ pub enum Trigger {
     Exit,
     Impulse,
     Resize,
-    Input(Key),
+    Input(Input),
 }
 
 /// Keyboard events submitted by users to interact with the application
-pub enum Key {
+pub enum Input {
     Escape,
     Down,
     Up,
     Right,
     Left,
+    AltDown,
+    AltUp,
+    AltRight,
+    AltLeft,
     S,
     G,
-    P,
-    N,
-    I,
-    O,
     Submit,
 }
 

--- a/src/triggers/mod.rs
+++ b/src/triggers/mod.rs
@@ -33,14 +33,15 @@ pub enum Trigger {
 
 /// Keyboard events submitted by users to interact with the application
 pub enum Key {
+    Escape,
     Down,
     Up,
     Right,
     Left,
     S,
-    H,
-    L,
     G,
+    P,
+    N,
     Submit,
 }
 

--- a/src/triggers/mod.rs
+++ b/src/triggers/mod.rs
@@ -42,6 +42,8 @@ pub enum Key {
     G,
     P,
     N,
+    I,
+    O,
     Submit,
 }
 

--- a/src/ui/chart.rs
+++ b/src/ui/chart.rs
@@ -73,6 +73,7 @@ impl MetricsChart {
                 calculate_x_value_of_timestamp(metrics_view.span().end(), self.resolution),
             ])
             .labels(labels)
+            .labels_alignment(Alignment::Right)
     }
 
     fn define_y_axis(&self, metrics_view: &MetricView) -> Axis {
@@ -81,9 +82,6 @@ impl MetricsChart {
 
         let labels = vec![
             Span::from("0"),
-            // To keep the first X-axis label from resizing the chart when its length changes:
-            // TODO remove this once issue #567 from tui-rs is solved (or PR #568 is merged)
-            Span::from("           "),
             Span::from(metrics_view.concise_repr_of_value(upper_bound)),
         ];
 

--- a/src/ui/metadata.rs
+++ b/src/ui/metadata.rs
@@ -1,4 +1,5 @@
 use std::time::Duration;
+use std::fmt::Write;
 
 use tui::layout::Alignment;
 use tui::style::{Color, Style};
@@ -75,7 +76,7 @@ fn render_process_info(frame: &mut FrameRegion, pm: &ProcessMetadata) {
 
     if pm.status() == Status::DEAD {
         let end_time = relative_timestamp_label(pm.running_span().end());
-        right_text.push_str(&format!(" - Dead {}", end_time));
+        let _ = write!(right_text, " - Dead {}", end_time);
     }
 
     let should_draw_right_paragraph = frame.region().width as usize > left_text.len() + right_text.len();

--- a/src/ui/metadata.rs
+++ b/src/ui/metadata.rs
@@ -1,5 +1,5 @@
-use std::time::Duration;
 use std::fmt::Write;
+use std::time::Duration;
 
 use tui::layout::Alignment;
 use tui::style::{Color, Style};


### PR DESCRIPTION
This merge request adds a way for the user to change the span of the central chart.

Following usual vim keybindings, the J key zooms out while the K key zooms in.

The reasoning behind these keybindings is that in vim, j moves the cursor down and k moves the cursor up.

When pressing J, we can imagine moving away from the graph and seeing a larger section of it.
When pressing K, we can imagine moving toward the graph and zooming on a section of it.

The user cannot zoom in to less than a 15 seconds window of the chart. Zooming out doubles the current window of the chart (15s :arrow_right: 30s :arrow_right: 60s :arrow_right:...) until the chart covers all recorded metrics.